### PR TITLE
refactor(result): changes generic types

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,12 +5,90 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ---
+### 1.14.0 - 2022-09-27
+
+### Change
+
+- refactor: Fail
+- refactor: Ok
+- refactor: Result.Ok
+- refactor: Result.fail
+
+Change generic types order for `Result.fail` and `Result.Ok`
+
+Now each method has your own order
+Example: 
+
+```ts
+
+// for implementation: 
+IResult<Payload, Error, MetaData>;
+
+// before the generic order was the same for both method.
+// now for 
+Result.Ok
+
+// the generic order is 
+Result.Ok<Payload, MetaData, Error>(payload metaData);
+
+// for 
+Result.fail 
+
+//the generic order is 
+Result.fail<Error, MetaData, Payload>(error, metaData);
+
+```
+
+Changes made on Ok
+
+```ts
+
+import { Ok } from 'rich-domain';
+
+// simple use case for success. no arg required
+return Ok();
+
+// arg required 
+
+return Ok<string>('my payload');
+
+// arg and metaData required 
+
+interface MetaData {
+  arg: string;
+}
+
+return Ok<string, MetaData>('payload', { arg: 'sample' })
+```
+
+Changes made on Fail
+
+```ts
+
+import { Fail } from 'rich-domain';
+
+// simple use case for success. no arg required
+return Fail();
+
+// arg required 
+
+return Fail<string>('my payload');
+
+// arg and metaData required 
+
+interface MetaData {
+  arg: string;
+}
+
+return Fail<string, MetaData>('payload', { arg: 'sample' })
+```
+---
 ### 1.13.0 - 2022-09-26
 
 ### Added
 
-feat: implement function Fail
-feat: implement function Ok
+- feat: implement function Fail
+- feat: implement function Ok
 
 ---
 ### 1.12.0 - 2022-09-14

--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ What is Result:
 
 #### Interface and Generic Types
 
-- A = `Payload` optional default `void`
-- B = `Error` optional default `string`
-- C = `MetaData` optional default `{}`
+- P = `Payload` optional default `void`
+- E = `Error` optional default `string`
+- M = `MetaData` optional default `{}`
 
 ```ts
 
-IResult<A, B, C>;
+IResult<P, E, M>;
 
 ```
 
@@ -125,11 +125,11 @@ import { Result, Ok, Fail } from "rich-domain";
 
 // Success use case
 
-return Result.Ok<void>();
+return Result.Ok();
 
 // OR
 
-return Ok<void>(null);
+return Ok();
 
 // Failure use case
 
@@ -552,8 +552,8 @@ export class Name extends ValueObject<NameProps>{
 		super(props);
 	}
 
-	public static create(props: NameProps): IResult<Name> {
-		return Result.Ok(new Name(props));
+	public static create(value: string): IResult<Name> {
+		return Result.Ok(new Name({ value }));
 	}
 }
 
@@ -566,7 +566,7 @@ The `create` method returns an instance of Name encapsulated by the `Result`, so
 
 ```ts
 
-const result = Name.create({ value: 'Jane' });
+const result = Name.create('Jane');
 
 console.log(result.isOk());
 
@@ -647,7 +647,7 @@ A validator instance is available in the "Value Object" domain class.
 
 ```ts
 
-import { IResult, Result, ValueObject } from "rich-domain";
+import { IResult, Ok, Fail, ValueObject } from "rich-domain";
 
 export interface NameProps {
 	value: string;
@@ -663,12 +663,12 @@ export class Name extends ValueObject<NameProps>{
 		return string(value).hasLengthBetween(3, 30);
 	}
 
-	public static create(props: NameProps): IResult<Name> {
+	public static create(value: string): IResult<Name> {
 		const message = 'name must have length min 3 and max 30 char';
 
-		if (!this.isValidProps(props)) return Result.fail(message);
+		if (!this.isValidProps({ value })) return Fail(message);
 
-		return Result.Ok(new Name(props));
+		return Ok(new Name({ value }));
 	}
 }
 
@@ -682,7 +682,7 @@ Now when you try to instantiate a name, the value will be checked and if it does
 
 const empty = '';
 
-const result = Name.create({ value: empty });
+const result = Name.create(empty);
 
 console.log(result.isFail());
 
@@ -728,7 +728,7 @@ Let's see a complete example as below
 
 ```ts
 
-import { IResult, Result, ValueObject } from "rich-domain";
+import { IResult, Ok, Fail, ValueObject } from "rich-domain";
 
 export interface NameProps {
 	value: string;
@@ -748,12 +748,12 @@ export class Name extends ValueObject<NameProps>{
 		return string(value).hasLengthBetween(3, 30);
 	}
 
-	public static create(props: NameProps): IResult<Name> {
+	public static create(value: string): IResult<Name> {
 		const message = 'name must have length min 3 and max 30 char';
 
-		if (!this.isValidProps(props)) return Result.fail(message);
+		if (!this.isValidProps({ value })) return Fail(message);
 
-		return Result.Ok(new Name(props));
+		return Ok(new Name({ value }));
 	}
 }
 
@@ -766,7 +766,7 @@ Value is not modified if it does not pass validation.
 
 ```ts
 
-const result = Name.create({ value: 'Jane' });
+const result = Name.create('Jane');
 
 console.log(result.isOk());
 
@@ -800,9 +800,9 @@ This method is useful for cases where you have value objects inside other value 
 
 ```ts
 
-const street = Street.create({ value: 'Dom Juan' }).value();
+const street = Street.create('Dom Juan').value();
 
-const number = Number.create({ value: 42 }).value();
+const number = Number.create(42).value();
 
 const result = Address.create({ street, number });
 
@@ -823,7 +823,7 @@ This method creates a new instance with the same properties as the current value
 
 ```ts
 
-const result = Name.create({ value: 'Sammy' });
+const result = Name.create('Sammy');
 
 const originalName = result.value();
 
@@ -932,8 +932,8 @@ All attributes for an entity must be value object except id.
 
 ```ts
 
-const nameAttr = Name.create({ value: 'James' });
-const ageAttr = Name.create({ value: 21 });
+const nameAttr = Name.create('James');
+const ageAttr = Name.create(21);
 
 // always check if value objects are success
 const voResult = Result.combine([nameAttr, ageAttr])
@@ -1089,7 +1089,7 @@ in entities you can easily change an attribute with `change` or `set` method
 
 ```ts
 
-const result = Name.create({ value: 'Larry' });
+const result = Name.create('Larry');
 
 const newName = result.value();
 
@@ -1195,7 +1195,7 @@ const user = result.value();
 
  const newUser = clonedUser.value();
 
- const newNameResult = Name.create({ value: 'Luke' });
+ const newNameResult = Name.create('Luke');
 
  const newName = newNameResult.value();
 

--- a/lib/core/fail.ts
+++ b/lib/core/fail.ts
@@ -16,8 +16,44 @@ import Result from "./result";
  * @argument P generic type for payload.
  * @default void as no state.
  */
-export const Fail = <E = string, M extends {} = {}, P = void>(error: E extends void ? null : E, metaData?: M): IResult<P, E, M> => {
-	return Result.fail(error ?? 'void error' as E, metaData);
+function Fail(): IResult<string, string, {}>;
+
+/**
+ * @description Create an instance of Result as failure state.
+ * @param error generic type E
+ * @param metaData generic type M
+ * @returns instance of Result as failure state
+ * 
+ * @augments E generic type for error.
+ * @default string.
+ * 
+ * @argument M generic type for metaData.
+ * @default Object empty object {}.
+ * 
+ * @argument P generic type for payload.
+ * @default void as no state.
+ */
+function Fail<E, M extends {} = {}, P = void>(error: E extends void ? null : E, metaData?: M): IResult<P, E extends void ? string : E, M>;
+
+/**
+ * @description Create an instance of Result as failure state.
+ * @param error generic type E
+ * @param metaData generic type M
+ * @returns instance of Result as failure state
+ * 
+ * @augments E generic type for error.
+ * @default string.
+ * 
+ * @argument M generic type for metaData.
+ * @default Object empty object {}.
+ * 
+ * @argument P generic type for payload.
+ * @default void as no state.
+ */
+function Fail<E = string, M extends {} = {}, P = void>(error?: E extends void ? null : E, metaData?: M): IResult<P, E extends void ? string : E, M> {
+	const _error = (typeof error !== 'undefined' && error !== null) ? error : 'void error. no message!';
+	return Result.fail(_error as any, metaData);
 }
 
 export default Fail;
+export { Fail };

--- a/lib/core/ok.ts
+++ b/lib/core/ok.ts
@@ -16,8 +16,43 @@ import Result from "./result";
  * @argument P generic type for payload.
  * @default void as no state.
  */
-export const Ok = <P = void, M extends {} = {}, E = string>(data: P extends void ? null : P, metaData?: M): IResult<P, E, M> => {
+function Ok(): IResult<void, string, {}>;
+
+/**
+ * @description Create an instance of Result as success state.
+ * @param data generic type P
+ * @param metaData generic type M
+ * @returns instance of Result as failure state
+ * 
+ * @augments E generic type for error.
+ * @default string.
+ * 
+ * @argument M generic type for metaData.
+ * @default Object empty object {}.
+ * 
+ * @argument P generic type for payload.
+ * @default void as no state.
+ */
+function Ok<P, M extends {} = {}, E = string>(data: P extends void ? null : P, metaData?: M): IResult<P, E, M>;
+
+/**
+ * @description Create an instance of Result as success state.
+ * @param data generic type P
+ * @param metaData generic type M
+ * @returns instance of Result as failure state
+ * 
+ * @augments E generic type for error.
+ * @default string.
+ * 
+ * @argument M generic type for metaData.
+ * @default Object empty object {}.
+ * 
+ * @argument P generic type for payload.
+ * @default void as no state.
+ */
+function Ok<P, M extends {} = {}, E = string>(data?: P extends void ? null : P, metaData?: M): IResult<P, E, M> {
 	return Result.Ok(data as P, metaData);
 }
 
 export default Ok;
+export { Ok };

--- a/lib/core/result.ts
+++ b/lib/core/result.ts
@@ -9,7 +9,7 @@ import Iterator from "./iterator";
  * @default D is string.
  * @default M is empty object {}.
  */
- export class Result<T = void, D = string, M = {}> implements IResult<T, D, M> {
+export class Result<T = void, D = string, M = {}> implements IResult<T, D, M> {
 
 	private readonly _isSuccess: boolean;
 	private readonly _isFailure: boolean;
@@ -29,22 +29,23 @@ import Iterator from "./iterator";
 	 * @description Create an instance of Result as success state.
 	 * @returns instance of Result<void>.
 	 */
-	 public static Ok(): Result<void>;
+	public static Ok(): Result<void>;
 	/**
 	 * @description Create an instance of Result as success state with data and metadata to payload.
 	 * @param data as T to payload.
 	 * @param metaData as M to state.
 	 * @returns instance of Result.
 	 */
-	public static Ok<T, D, M>(data: T, metaData?: M): Result<T, D, M>;
+	public static Ok<T, M = {}, D = string>(data: T, metaData?: M): Result<T, D, M>;
 	/**
 	 * @description Create an instance of Result as success state with data and metadata to payload.
 	 * @param data as T to payload.
 	 * @param metaData as M to state.
 	 * @returns instance of Result.
 	 */
-	public static Ok<T, D, M>(data?: T, metaData?: M): Result<T, D, M> {
-		return new Result(true, data, null, metaData) as unknown as Result<T, D, M>;
+	public static Ok<T, M = {}, D = string>(data?: T, metaData?: M): Result<T, D, M> {
+		const _data = typeof data === 'undefined' ? null : data;
+		return new Result(true, _data, null, metaData) as unknown as Result<T, D, M>;
 	}
 
 	/**
@@ -53,8 +54,9 @@ import Iterator from "./iterator";
 	 * @param metaData as M to state.
 	 * @returns instance of Result.
 	 */
-	public static fail<T, D, M>( error: D, metaData?: M): Result<T, D, M> {
-		return new Result(false, null, error, metaData) as unknown as Result<T, D, M>;
+	public static fail<D = string, M = {}, T = void>(error?: D, metaData?: M): Result<T, D, M> {
+		const _error = typeof error !== 'undefined' && error !== null ? error : 'void error. no message!';
+		return new Result(false, null, _error, metaData) as unknown as Result<T, D, M>;
 	}
 	/**
 	 * @description Create an instance of Iterator with array of Results on state.
@@ -73,7 +75,7 @@ import Iterator from "./iterator";
 	 */
 	public static combine<A, B, M>(results: Array<Result<A, B, M>>): Result<A, B, M> {
 		const iterator = this.iterate(results);
-		if (iterator.isEmpty()) return Result.fail<A, B, M>('No results provided on combine param' as unknown as B);
+		if (iterator.isEmpty()) return Result.fail<B, M, A>('No results provided on combine param' as unknown as B);
 		while (iterator.hasNext()) {
 			const currentResult = iterator.next();
 			if (currentResult.isFail()) return currentResult;
@@ -86,7 +88,7 @@ import Iterator from "./iterator";
 	 * @param command instance of command that implements ICommand interface.
 	 * @returns Command result as payload.
 	 */
-	execute<X, Y>(command: ICommand<X|void, Y>): IResultExecute<X, Y> {
+	execute<X, Y>(command: ICommand<X | void, Y>): IResultExecute<X, Y> {
 		return {
 			/**
 			 * @description Use this option the command does not require arguments.
@@ -178,6 +180,6 @@ import Iterator from "./iterator";
 			metaData: this._metaData as M
 		}
 	}
- }
+}
 
 export default Result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.13.0",
+	"version": "1.14.0",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/tests/core/fail.spec.ts
+++ b/tests/core/fail.spec.ts
@@ -1,12 +1,19 @@
 import Fail from "../../lib/core/fail";
+import Result from "../../lib/core/result";
 
-describe('ok', () => {
+describe('fail', () => {
+
+	it('should create a simple no args failure', () => {
+		const result = Fail();
+		expect(result.isOk()).toBeFalsy();
+		expect(result.isFail()).toBeTruthy();
+	});
 
 	it('should create a simple failure', () => {
 		const result = Fail('internal server error');
 		expect(result.isOk()).toBeFalsy();
 		expect(result.isFail()).toBeTruthy();
-	})
+	});
 
 	it('should create a failure result as void', () => {
 		const result = Fail<void>(null);
@@ -14,7 +21,7 @@ describe('ok', () => {
 		expect(result.isFail()).toBeTruthy();
 		expect(result.toObject()).toEqual({
 			"data": null,
-			"error": 'void error',
+			"error": 'void error. no message!',
 			"isFail": true,
 			"isOk": false,
 			"metaData": {},
@@ -32,7 +39,7 @@ describe('ok', () => {
 		expect(result.isFail()).toBeTruthy();
 		expect(result.toObject()).toEqual({
 			"data": null,
-			"error": 'void error',
+			"error": 'void error. no message!',
 			"isFail": true,
 			"isOk": false,
 			"metaData": { ping: 'pong' },
@@ -103,6 +110,54 @@ describe('ok', () => {
 			"isFail": true,
 			"isOk": false,
 			"metaData": { arg: 'invalid@mail.com' },
+		});
+	});
+
+	describe('generic types', () => {
+
+		type Error = { message: string };
+		type Payload = { data: { status: number } };
+		type MetaData = { args: number };
+
+		it('should fail generate the same payload as result', () => {
+
+			const status: number = 400;
+			const metaData: MetaData = { args: status };
+			const error: Error = { message: 'something went wrong!' };
+
+			const resultInstance = Result.fail<Error, MetaData, Payload>(error, metaData);
+			const okInstance = Fail<Error, MetaData, Payload>(error, metaData);
+
+			expect(resultInstance.toObject()).toEqual(okInstance.toObject());
+
+		});
+
+		it('should fail generate the same payload as result', () => {
+
+			const resultInstance = Result.fail();
+			const okInstance = Fail();
+
+			expect(resultInstance.toObject()).toEqual(okInstance.toObject());
+
+		});
+
+
+		it('should fail generate the same payload as result', () => {
+
+			const resultInstance = Result.fail('hey there');
+			const okInstance = Fail('hey there');
+
+			expect(resultInstance.toObject()).toEqual(okInstance.toObject());
+
+		});
+
+		it('should fail generate the same payload as result', () => {
+
+			const resultInstance = Result.fail('hey there', { status: 400 });
+			const okInstance = Fail('hey there', { status: 400 });
+
+			expect(resultInstance.toObject()).toEqual(okInstance.toObject());
+
 		});
 	});
 });

--- a/tests/core/ok.spec.ts
+++ b/tests/core/ok.spec.ts
@@ -1,12 +1,19 @@
 import Ok from "../../lib/core/ok";
+import Result from "../../lib/core/result";
 
 describe('ok', () => {
 
-	it('should create a simple success', () => {
+	it('should create a simple success with no args', () => {
+		const result = Ok();
+		expect(result.isOk()).toBeTruthy();
+		expect(result.isFail()).toBeFalsy();
+	});
+
+	it('should create a simple success with null value', () => {
 		const result = Ok(null);
 		expect(result.isOk()).toBeTruthy();
 		expect(result.isFail()).toBeFalsy();
-	})
+	});
 
 	it('should create a success result as void', () => {
 		const result = Ok<void>(null);
@@ -105,6 +112,54 @@ describe('ok', () => {
 			"isFail": false,
 			"isOk": true,
 			"metaData": { arg: 'my argument' },
+		});
+	});
+
+	describe('generic types', () => {
+
+		type Error = { message: string };
+		type Payload = { data: { status: number } };
+		type MetaData = { args: number };
+
+		it('should ok generate the same payload as result', () => {
+
+			const status: number = 200;
+			const payload: Payload = { data: { status } };
+			const metaData: MetaData = { args: status };
+
+			const resultInstance = Result.Ok<Payload, MetaData, Error>(payload, metaData);
+			const okInstance = Ok<Payload, MetaData, Error>(payload, metaData);
+
+			expect(resultInstance.toObject()).toEqual(okInstance.toObject());
+
+		});
+
+		it('should ok generate the same payload as result', () => {
+
+			const resultInstance = Result.Ok();
+			const okInstance = Ok();
+
+			expect(resultInstance.toObject()).toEqual(okInstance.toObject());
+
+		});
+
+
+		it('should ok generate the same payload as result', () => {
+
+			const resultInstance = Result.Ok('hey there');
+			const okInstance = Ok('hey there');
+
+			expect(resultInstance.toObject()).toEqual(okInstance.toObject());
+
+		});
+
+		it('should ok generate the same payload as result', () => {
+
+			const resultInstance = Result.Ok('hey there', { status: 200 });
+			const okInstance = Ok('hey there', { status: 200 });
+
+			expect(resultInstance.toObject()).toEqual(okInstance.toObject());
+
 		});
 	});
 });

--- a/tests/core/result.spec.ts
+++ b/tests/core/result.spec.ts
@@ -14,7 +14,7 @@ describe('result', () => {
 
 	describe('failure', () => {
 		it('should be fail', () => {
-			
+
 			const result = Result.fail('fail', { message: 'some metadata info' });
 
 			expect(result.error()).toBe('fail');
@@ -39,7 +39,7 @@ describe('result', () => {
 		const success3 = Result.Ok(3);
 
 		it('should return first if success', () => {
-			expect(Result.combine([ success1, success2, success3 ]).value()).toBe(1);
+			expect(Result.combine([success1, success2, success3]).value()).toBe(1);
 		});
 
 		it('should execute a command on success', () => {


### PR DESCRIPTION

### Change

- refactor: Fail
- refactor: Ok
- refactor: Result.Ok
- refactor: Result.fail

Change generic types order for `Result.fail` and `Result.Ok`

Now each method has your own order
Example: 

```ts

// for implementation: 
IResult<Payload, Error, MetaData>;

// before the generic order was the same for both method.
// now for 
Result.Ok

// the generic order is 
Result.Ok<Payload, MetaData, Error>(payload metaData);

// for 
Result.fail 

//the generic order is 
Result.fail<Error, MetaData, Payload>(error, metaData);

```

Changes made on Ok

```ts

import { Ok } from 'rich-domain';

// simple use case for success. no arg required
return Ok();

// arg required 

return Ok<string>('my payload');

// arg and metaData required 

interface MetaData {
  arg: string;
}

return Ok<string, MetaData>('payload', { arg: 'sample' })
```

Changes made on Fail

```ts

import { Fail } from 'rich-domain';

// simple use case for success. no arg required
return Fail();

// arg required 

return Fail<string>('my payload');

// arg and metaData required 

interface MetaData {
  arg: string;
}

return Fail<string, MetaData>('payload', { arg: 'sample' })
```
