### PR TITLE
feat(change): mark change and set function as deprecated

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ---
+### 1.15.0 - 2022-11-29
+
+### Changed
+
+- value-object: mark set function as deprecated
+- value-object: mark change function as deprecated
+
+The function still works, but it is marked as deprecated. show warning if using.
+
+---
 ### 1.14.6 - 2022-11-27
 
 ### Fixed

--- a/lib/core/value-object.ts
+++ b/lib/core/value-object.ts
@@ -35,6 +35,28 @@ export class ValueObject<Props> extends GettersAndSetters<Props> implements IVal
 		return this.autoMapper.valueObjectToObj(this) as unknown as T;
 	}
 
+	/** 
+	 * @description use immutable value object.
+	 * @deprecated do not use `set` function to change `value-object` state. 
+	 * @access create a new instance instead
+	 * @method `set` function will be removed for `value-objects` in future version.
+	 */
+	set<Key extends keyof Props>(key: Key): { 
+		to: (value: Props[Key], validation?: ((value: Props[Key]) => boolean) | undefined) => GettersAndSetters<Props>; 
+	} {
+		return super.set(key);
+	}
+
+	/** 
+	 * @description use immutable value object.
+	 * @deprecated do not use change function to modify `value-object` state.
+	 * @access create a new instance instead
+	 * @method `change` function will be removed for `value-objects` in future version.
+	 */
+	change<Key extends keyof Props>(key: Key, value: Props[Key], validation?: ((value: Props[Key]) => boolean) | undefined): this {
+		return super.change(key, value, validation);
+	}
+
 	/**
 	 * @description Method to validate prop value.
 	 * @param props to validate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.14.6",
+	"version": "1.15.0",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/tests/core/entity.spec.ts
+++ b/tests/core/entity.spec.ts
@@ -128,6 +128,14 @@ describe("entity", () => {
 			expect(ent.value().id.value()).not.toBe('changed');
 		});
 
+		it('should set prototype', () => {
+			const ent = EntitySample.create({ foo: 'bar' });
+			expect(ent.isOk()).toBeTruthy();
+			expect(ent.value().get('foo')).toBe('bar');
+			ent.value().set('foo').to('changed');
+			expect(ent.value().get('foo')).toBe('changed');
+		});
+
 		it('should create many entities', () => {
 			const payload = EntitySample.createMany([]);
 			expect(payload.result.isFail()).toBeTruthy();


### PR DESCRIPTION
- value-object: mark set function as deprecated
- value-object: mark change function as deprecated

The function still works, but it is marked as deprecated. show warning if using.