### PR TITLE
feat(validator): change validation methods

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ---
-### 1.15.0 - 2022-11-29
+### 1.15.0 - 2022-12-25
 
 ### Changed
 
 - value-object: mark set function as deprecated
 - value-object: mark change function as deprecated
+- validator: change methods for string (hasLengthBetween - now validate only interval)
+- validator: rename method isPair to isEven
+
+### Added
+
+- validator - string added method hasLengthBetweenOrEqual
+- validator - number isBetweenOrEqual
 
 The function still works, but it is marked as deprecated. show warning if using.
 

--- a/lib/utils/validator.ts
+++ b/lib/utils/validator.ts
@@ -76,9 +76,10 @@ export class Validator {
 				target <= Number.MAX_SAFE_INTEGER && target >= Number.MIN_SAFE_INTEGER,
 			isPositive: (): boolean => Validator.instance.isNumber(target) && target >= 0,
 			isNegative: (): boolean => Validator.instance.isNumber(target) && target < 0,
-			isPair: (): boolean => Validator.instance.isNumber(target) && target % 2 === 0,
+			isEven: (): boolean => Validator.instance.isNumber(target) && target % 2 === 0,
 			isInteger: (): boolean => Validator.instance.isNumber(target) && target - Math.trunc(target) === 0,
-			isBetween: (min: number, max: number): boolean => Validator.instance.isNumber(target) && target < max && target > min
+			isBetween: (min: number, max: number): boolean => Validator.instance.isNumber(target) && target < max && target > min,
+			isBetweenOrEqual: (min: number, max: number): boolean => Validator.instance.isNumber(target) && target <= max && target >= min
 		}
 	}
 	string(target: string) {
@@ -89,6 +90,8 @@ export class Validator {
 			hasLengthLessOrEqualTo: (length: number): boolean => Validator.instance.isString(target) && target.length <= length,
 			hasLengthEqualTo: (length: number): boolean => Validator.instance.isString(target) && target.length === length,
 			hasLengthBetween: (min: number, max: number): boolean => Validator.instance.isString(target) &&
+				target.length > min && target.length < max,
+			hasLengthBetweenOrEqual: (min: number, max: number): boolean => Validator.instance.isString(target) &&
 				target.length >= min && target.length <= max,
 			includes: (value: string): boolean => Validator.instance.isString(target) && target.includes(value) || value.split('').map((char) => target.includes(char)).includes(true),
 			isEmpty: (): boolean => (Validator.instance.isUndefined(target) ||

--- a/tests/utils/validator.spec.ts
+++ b/tests/utils/validator.spec.ts
@@ -568,6 +568,46 @@ describe('check-types', () => {
 			const result = checker.isNumber(ent.value());
 			expect(result).toBeFalsy();
 		});
+
+		it('should 10 to be between 1 and 20', () => {
+			const result = checker.number(10).isBetween(1, 20);
+			expect(result).toBeTruthy();
+		});
+
+		it('should 0 not to be between 1 and 20', () => {
+			const result = checker.number(0).isBetween(1, 20);
+			expect(result).toBeFalsy();
+		});
+
+		it('should 10 not to be between 1 and 2', () => {
+			const result = checker.number(10).isBetween(1, 2);
+			expect(result).toBeFalsy();
+		});
+
+		it('should 10 to be between 1 and 20', () => {
+			const result = checker.number(10).isBetweenOrEqual(1, 20);
+			expect(result).toBeTruthy();
+		});
+
+		it('should 0 not to be between or equal 1 and 20', () => {
+			const result = checker.number(0).isBetweenOrEqual(1, 20);
+			expect(result).toBeFalsy();
+		});
+
+		it('should 21 not to be between or equal 1 and 20', () => {
+			const result = checker.number(21).isBetweenOrEqual(1, 20);
+			expect(result).toBeFalsy();
+		});
+
+		it('should 1 to be between or equal 1 and 2', () => {
+			const result = checker.number(1).isBetweenOrEqual(1, 2);
+			expect(result).toBeTruthy();
+		});
+
+		it('should 2 to be between or equal 1 and 2', () => {
+			const result = checker.number(2).isBetweenOrEqual(1, 2);
+			expect(result).toBeTruthy();
+		});
 	});
 
 	describe('date', () => {
@@ -1088,7 +1128,6 @@ describe('check-types', () => {
 				expect(checker.number(10).isGreaterThan(11)).toBeFalsy();
 			});
 
-
 			it('should 12 to be integer', () => {
 				expect(checker.number(12).isInteger()).toBeTruthy();
 			});
@@ -1098,11 +1137,11 @@ describe('check-types', () => {
 			});
 
 			it('should 12 to be pair', () => {
-				expect(checker.number(12).isPair()).toBeTruthy();
+				expect(checker.number(12).isEven()).toBeTruthy();
 			});
 
 			it('should 7 not to be pair', () => {
-				expect(checker.number(7).isPair()).toBeFalsy();
+				expect(checker.number(7).isEven()).toBeFalsy();
 			});
 
 			it('should -1 to be negative', () => {
@@ -1157,6 +1196,22 @@ describe('check-types', () => {
 
 			it('should lorem ipsum not to has length between 1 and 10', () => {
 				expect(checker.string('lorem ipsum').hasLengthBetween(1, 10)).toBeFalsy();
+			});
+
+			it('should lorem ipsu to has length between 1 and 10', () => {
+				expect(checker.string('lorem ipsu').hasLengthBetweenOrEqual(1, 10)).toBeTruthy();
+			});
+
+			it('should empty not to has length between 1 and 10', () => {
+				expect(checker.string('').hasLengthBetweenOrEqual(1, 10)).toBeFalsy();
+			});
+
+			it('should long value string not to has length between 1 and 10', () => {
+				expect(checker.string('long value string').hasLengthBetweenOrEqual(1, 10)).toBeFalsy();
+			});
+
+			it('should 1 to has length between 1 and 10', () => {
+				expect(checker.string('1').hasLengthBetweenOrEqual(1, 10)).toBeTruthy();
 			});
 
 			it('should to be empty', () => {
@@ -1230,7 +1285,6 @@ describe('check-types', () => {
 			it('should abcd to have length less than 5', () => {
 				expect(checker.string('abcd').hasLengthLessThan(5)).toBeTruthy();
 			});
-
 
 			it('should abcde not includes 7', () => {
 				expect(checker.string('abcde').includes('7')).toBeFalsy();


### PR DESCRIPTION
### 1.15.0 - 2022-12-25

### Changed

- value-object: mark set function as deprecated
- value-object: mark change function as deprecated

The function still works, but it is marked as deprecated. show warning if using.

- validator: change methods for string (hasLengthBetween - now validate only interval)
- validator: rename method isPair to isEven

### Added

- validator - string added method hasLengthBetweenOrEqual
- validator - number isBetweenOrEqual

