### PR TITLE
fix(auto-mapper): fix processing simple object

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ---
+### 1.15.2 - 2022-01-05
+
+### Fixed
+
+- toObject method on entity: fix error on process simple object on entity [issue #25](https://github.com/4lessandrodev/rich-domain/issues/25)
+
+---
 ### 1.15.1 - 2022-01-03
 
 ### Changed

--- a/lib/core/auto-mapper.ts
+++ b/lib/core/auto-mapper.ts
@@ -114,7 +114,6 @@ import ID from "./id";
 		const isSimpleValue = this.validator.isBoolean(entity) ||
 			this.validator.isNumber(entity) ||
 			this.validator.isString(entity) ||
-			this.validator.isObject(entity) ||
 			this.validator.isDate(entity);
 		
 		if (isSimpleValue) return entity as any;
@@ -151,16 +150,17 @@ import ID from "./id";
 				this.validator.isBoolean(props?.[key as any]) ||
 				this.validator.isNumber(props?.[key as any]) ||
 				this.validator.isString(props?.[key as any]) ||
+				this.validator.isObject(props?.[key as any]) ||
 				this.validator.isDate(props?.[key as any]);
+
 				const isEntity = this.validator.isEntity(props?.[key as any]);
 
-				if (isSimple) {
-					const data = this.valueObjectToObj(props[key as any] as any);
+				if (isEntity) {
+					const data = this.entityToObj(props[key as any] as any);
 
 					result = Object.assign({}, { ...result }, { [key]: data });
-
-				} else if(isEntity) {
-					const data = this.entityToObj(props[key as any] as any);
+				} else if(isSimple) {
+					const data = this.valueObjectToObj(props[key as any] as any);
 
 					result = Object.assign({}, { ...result }, { [key]: data });
 				}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.15.1",
+	"version": "1.15.2",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/tests/core/auto-mapper.spec.ts
+++ b/tests/core/auto-mapper.spec.ts
@@ -18,7 +18,7 @@ describe('auto-mapper', () => {
 			const autoMapper = new AutoMapper();
 
 			const result = autoMapper.valueObjectToObj(vo.value());
-			
+
 			expect(result).toBe('hello');
 
 		});
@@ -36,7 +36,7 @@ describe('auto-mapper', () => {
 			const autoMapper = new AutoMapper();
 
 			const result = autoMapper.valueObjectToObj(vo.value());
-			
+
 			expect(result).toEqual({ value: 'hello', age: 21 });
 
 		});
@@ -56,7 +56,7 @@ describe('auto-mapper', () => {
 
 			const result1 = autoMapper.valueObjectToObj(vo1.value());
 			const result2 = autoMapper.valueObjectToObj(vo2.value());
-			
+
 			expect(result1).toEqual({ value: 'hello', isActive: true });
 			expect(result2).toEqual({ value: 'hello', isActive: false });
 
@@ -70,13 +70,13 @@ describe('auto-mapper', () => {
 				}
 			}
 
-			const vo = StringVo.create({ value: 'hello', notes: [1,2,3,4,5,6,7] });
+			const vo = StringVo.create({ value: 'hello', notes: [1, 2, 3, 4, 5, 6, 7] });
 
 			const autoMapper = new AutoMapper();
 
 			const result = autoMapper.valueObjectToObj(vo.value());
-			
-			expect(result).toEqual({ value: 'hello', notes: [1,2,3,4,5,6,7] });
+
+			expect(result).toEqual({ value: 'hello', notes: [1, 2, 3, 4, 5, 6, 7] });
 
 		});
 
@@ -88,13 +88,13 @@ describe('auto-mapper', () => {
 				}
 			}
 
-			const vo = StringVo.create({ value: [1,2,3,4,5,6,7] });
+			const vo = StringVo.create({ value: [1, 2, 3, 4, 5, 6, 7] });
 
 			const autoMapper = new AutoMapper();
 
 			const result = autoMapper.valueObjectToObj(vo.value());
-			
-			expect(result).toEqual([1,2,3,4,5,6,7]);
+
+			expect(result).toEqual([1, 2, 3, 4, 5, 6, 7]);
 
 		});
 
@@ -111,7 +111,7 @@ describe('auto-mapper', () => {
 			const autoMapper = new AutoMapper();
 
 			const result = autoMapper.valueObjectToObj(vo.value());
-			
+
 			expect(result).toBe('3c5738cf-825e-48b7-884d-927be849b0b6');
 
 		});
@@ -131,13 +131,13 @@ describe('auto-mapper', () => {
 			while (ids.hasNext()) {
 				IDS.push(ID.create(ids.next()));
 			}
-			
-			const vo = StringVo.create({ value:  IDS });
+
+			const vo = StringVo.create({ value: IDS });
 
 			const autoMapper = new AutoMapper();
 
 			const result = autoMapper.valueObjectToObj(vo.value());
-			
+
 			expect(result).toEqual(["927be849b0b1", "927be849b0b2", "927be849b0b3"]);
 
 		});
@@ -164,7 +164,7 @@ describe('auto-mapper', () => {
 			const autoMapper = new AutoMapper<{ value: StringVo2, message: string }>();
 
 			const result = autoMapper.valueObjectToObj(vo.value());
-			
+
 			expect(result).toEqual({ message: "text", value: { value: 'hello', age: 21 } });
 
 		});
@@ -194,7 +194,7 @@ describe('auto-mapper', () => {
 			const autoMapper = new AutoMapper<{ value: StringVo2, message: string }>();
 
 			const result = autoMapper.valueObjectToObj(vo.value());
-			
+
 			expect(result).toEqual({
 				message: "text",
 				value: {
@@ -238,7 +238,7 @@ describe('auto-mapper', () => {
 
 			const age = AgeVo.create({ value: 21 }).value();
 			const name = NameVo.create({ value: 'some value' }).value();
-			const agg = SimpleEntity.create({ id: "1519cb69-9904-4f2b-84e1-e6e95431cf24", age, name, notes: [1,2,3] });
+			const agg = SimpleEntity.create({ id: "1519cb69-9904-4f2b-84e1-e6e95431cf24", age, name, notes: [1, 2, 3] });
 
 			const user = agg.value();
 
@@ -247,13 +247,13 @@ describe('auto-mapper', () => {
 			const autoMapper = new AutoMapper<Props>();
 
 			const obj = autoMapper.entityToObj(user);
-			
+
 			expect(obj.id).toBe('1519cb69-9904-4f2b-84e1-e6e95431cf24');
 			expect(obj.age).toBe(21);
 			expect(obj.name).toBe('some value');
 			expect(obj.createdAt).toBeInstanceOf(Date);
 			expect(obj.updatedAt).toBeInstanceOf(Date);
-			expect(obj.notes).toEqual([1,2,3]);
+			expect(obj.notes).toEqual([1, 2, 3]);
 
 		});
 
@@ -262,19 +262,19 @@ describe('auto-mapper', () => {
 	describe('complex entity', () => {
 
 		class Price extends ValueObject<{ value: number }> {
-			private constructor(props: { value: number }){
+			private constructor(props: { value: number }) {
 				super(props)
 			}
 		}
 
 		class Name extends ValueObject<{ value: string }> {
-			private constructor(props: { value: string }){
+			private constructor(props: { value: string }) {
 				super(props)
 			}
 		}
 
 		class Item extends ValueObject<{ name: string }> {
-			private constructor(props: { name: string }){
+			private constructor(props: { name: string }) {
 				super(props)
 			}
 		}
@@ -292,7 +292,7 @@ describe('auto-mapper', () => {
 		}
 
 		class Product extends Entity<Props>{
-			private constructor(props: Props){
+			private constructor(props: Props) {
 				super(props);
 			}
 
@@ -316,7 +316,7 @@ describe('auto-mapper', () => {
 		}
 
 		class Order extends Aggregate<AggProps>{
-			private constructor(props: AggProps){
+			private constructor(props: AggProps) {
 				super(props);
 			}
 
@@ -327,7 +327,7 @@ describe('auto-mapper', () => {
 
 		const price = Price.create({ value: 20 }).value();
 		const name = Name.create({ value: "jane" }).value();
-		const item = Item.create({ name: "some-item"}).value();
+		const item = Item.create({ name: "some-item" }).value();
 
 		it('should convert an entity to simple object with success', () => {
 
@@ -342,7 +342,7 @@ describe('auto-mapper', () => {
 				price: 20,
 				amount: 42,
 				detail: 'detail info',
-				lastSales: [itemObj,itemObj,itemObj],
+				lastSales: [itemObj, itemObj, itemObj],
 				options: ['a', 'b', 'c'],
 				createdAt: now,
 				updatedAt: now,
@@ -379,7 +379,7 @@ describe('auto-mapper', () => {
 				price: 20,
 				amount: 42,
 				detail: 'detail info',
-				lastSales: [itemObj,itemObj,itemObj],
+				lastSales: [itemObj, itemObj, itemObj],
 				options: ['a', 'b', 'c'],
 				createdAt: now,
 				updatedAt: now,
@@ -393,7 +393,7 @@ describe('auto-mapper', () => {
 				price: 20,
 				amount: 42,
 				detail: 'detail info',
-				lastSales: [itemObj,itemObj,itemObj],
+				lastSales: [itemObj, itemObj, itemObj],
 				options: ['a', 'b', 'c'],
 				createdAt: now,
 				updatedAt: now,
@@ -423,4 +423,102 @@ describe('auto-mapper', () => {
 
 	})
 
+	describe("auto mapper entity with object", () => {
+
+		interface ValueA {
+			value: string;
+		}
+
+		interface ValueB {
+			value: number;
+		}
+
+		interface Detail {
+			nick: string;
+			site: string;
+			likes: number;
+			summary: string[];
+		}
+
+		class Name extends ValueObject<ValueA>{}
+		class Age extends ValueObject<ValueB>{}
+
+		interface PropsA {
+			id?: UID;
+			name: Name;
+			age: Age;
+			data: string;
+			value: number;
+			notes: number[];
+			detail: Detail;
+			createdAt: Date;
+		}
+
+		class Profile extends Entity<PropsA>{}
+		interface PropsB {
+			id?: UID;
+			profile: Profile;
+			isMarried: boolean;
+			value: number;
+			cite: string;
+			createdAt: Date;
+		}
+
+		class Example extends Entity<PropsB>{}
+
+		const profile = {
+			age: Age.create({ value: 21 }).value(),
+			data: 'lorem ipsum',
+			name: Name.create({ value: 'Mille'}).value(),
+			notes: [10,20,30],
+			value: 7,
+			id: Id('valid-uuid-2'),
+			createdAt: new Date('2023-01-05T18:20:41.916Z'),
+			detail:{
+				likes: 200,
+				nick: 'Loader',
+				site: '4dev.com',
+				summary: ['page1', 'page2']
+			}
+		} satisfies PropsA;
+
+		const props = {
+			cite: 'Lorem',
+			isMarried: true,
+			profile: Profile.create(profile).value(),
+			value: 42,
+			id: Id('valid-uuid-1'),
+			createdAt: new Date('2023-01-05T18:20:41.916Z'),
+		} satisfies PropsB;
+
+		const entity = Example.create(props).value();
+
+		it('should convert object on entity to simple object', () => {
+			const object = entity.toObject();
+			expect(object).toEqual({
+				id: "valid-uuid-1",
+				cite: 'Lorem',
+				createdAt: new Date("2023-01-05T18:20:41.916Z"),
+				updatedAt: expect.any(Date),
+				isMarried: true,
+				value: 42,
+				profile: {
+					age: 21,
+					data: 'lorem ipsum',
+					name: 'Mille',
+					notes: [10,20,30],
+					value: 7,
+					id: 'valid-uuid-2',
+					createdAt: new Date("2023-01-05T18:20:41.916Z"),
+					updatedAt: expect.any(Date),
+					detail:{
+						likes: 200,
+						nick: 'Loader',
+						site: '4dev.com',
+						summary: ['page1', 'page2']
+					}
+				}
+			});
+		})
+	});
 });


### PR DESCRIPTION
**Describe the bug**
toObject method on entity is not processing simple objects

**To Reproduce**
```ts

interface Profile {
  name: string;
  age: number;
}

interface Props {
  id?: UID;
  profile: Profile;
}

class Example extends Entity<Props>{}

const example = Example.create({ profile: { name: "Jane", age:21 } }).value();

console.log(example.toObject()):

> {  
       id: "4666ce4b-10d9-4999-9da8-0caef5b7fd50", 
       createdAt: "2023-01-05T18:34:54.198Z", 
       updatedAt: "2023-01-05T18:34:54.198Z" 
 };

```

**Expected behavior**
the toObject method should process simple object and apply it to generated props

```ts
console.log(example.toObject()):

> {  
       id: "4666ce4b-10d9-4999-9da8-0caef5b7fd50", 
       createdAt: "2023-01-05T18:34:54.198Z", 
       updatedAt: "2023-01-05T18:34:54.198Z",
       profile: { name: "Jane", age: 21 }
 };

```

**Lib Version**
rich-domain v1.15.1




#25 

