### PR TITLE
Feat/equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ---
+
+### 1.16.0 - 2022-01-12
+
+### Added
+
+- Entity: added method `isEqual` to compare current instance with another one.
+- ValueObject: added method `isEqual` to compare current instance with another one. [Issue 27](https://github.com/4lessandrodev/rich-domain/issues/27)
+
+---
 ### 1.15.2 - 2022-01-05
 
 ### Fixed

--- a/lib/core/entity.ts
+++ b/lib/core/entity.ts
@@ -18,6 +18,26 @@ import Result from "./result";
 		this.autoMapper = new AutoMapper();
 	}
 
+	/** 
+	 * @description Check if entity instance props is equal another provided instance props.
+	 * @param createdAt is not considered on comparation
+	 * @param updatedAt is not considered on comparation
+	 * @returns true if props is equal and false if not.
+	*/
+	isEqual(other: Entity<Props>): boolean {
+		const currentProps = Object.assign({}, {}, { ...this.props});
+		const providedProps = Object.assign({}, {}, { ...other.props});
+		delete currentProps?.['createdAt'];
+		delete currentProps?.['updatedAt'];
+		delete providedProps?.['createdAt'];
+		delete providedProps?.['updatedAt'];
+		const equalId = this.id.equal(other.id);
+		const serializedA = JSON.stringify(currentProps);
+		const serializedB = JSON.stringify(providedProps);		
+		const equalSerialized = serializedA === serializedB;
+		return equalId && equalSerialized;
+	}
+
 	/**
 	 * @description Get value as object from entity.
 	 * @returns object with properties.

--- a/lib/core/value-object.ts
+++ b/lib/core/value-object.ts
@@ -13,6 +13,22 @@ export class ValueObject<Props> extends GettersAndSetters<Props> implements IVal
 		this.autoMapper = new AutoMapper();
 	}
 
+	/** 
+	 * @description Check if value object instance props is equal another provided instance props.
+	 * @param createdAt is not considered on comparation
+	 * @param updatedAt is not considered on comparation
+	 * @returns true if props is equal and false if not.
+	*/
+	isEqual(other: ValueObject<Props>): boolean {
+		const currentProps = Object.assign({}, {}, { ...this.props});
+		const providedProps = Object.assign({}, {}, { ...other.props});
+		delete currentProps?.['createdAt'];
+		delete currentProps?.['updatedAt'];
+		delete providedProps?.['createdAt'];
+		delete providedProps?.['updatedAt'];
+		return JSON.stringify(currentProps) === JSON.stringify(providedProps);
+	}
+
 	/**
 	 * @description Get an instance copy.
 	 * @returns a new instance of value object.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.15.2",
+	"version": "1.16.0",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/tests/core/entity.spec.ts
+++ b/tests/core/entity.spec.ts
@@ -1,5 +1,5 @@
-import {  Entity, Result } from "../../lib/core";
-import { IResult } from "../../lib/types";
+import {  Entity, Id, Ok, Result } from "../../lib/core";
+import { IResult, UID } from "../../lib/types";
 
 describe("entity", () => {
 
@@ -139,6 +139,86 @@ describe("entity", () => {
 		it('should create many entities', () => {
 			const payload = EntitySample.createMany([]);
 			expect(payload.result.isFail()).toBeTruthy();
+		});
+	});
+
+	describe('compare', () => {
+
+		interface Val {
+			name: string;
+		}
+
+		interface Props {
+			id?: UID;
+			key: number;
+			values: Array<Val>;
+		}
+
+		class EntityExample extends Entity<Props>{
+			private constructor(props: Props) {
+				super(props)
+			}
+
+			public static create(props: Props): Result<EntityExample> {
+				return Ok(new EntityExample(props));
+			}
+		}
+
+		it("should to be equal", () => {
+
+			const props = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
+			const id = Id();
+
+			const a = EntityExample.create({...props, id }).value();
+			const b = EntityExample.create({...props, id}).value();
+			
+			expect(a.isEqual(b)).toBeTruthy();
+		});
+
+		it("should to be equal", () => {
+
+			const id = Id();
+			const props = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
+
+			const a = EntityExample.create({...props, id}).value();
+			const b = a.clone().value();
+			
+			expect(a.isEqual(b)).toBeTruthy();
+		});
+
+		it("should not to be equal if change state", () => {
+
+			const id = Id();
+			const props = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
+
+			const a = EntityExample.create({...props, id}).value();
+			const b = a.clone().value();
+			b.set('key').to(201);
+			
+			expect(a.isEqual(b)).toBeFalsy();
+		});
+
+		it("should not to be equal if state is different", () => {
+
+			const id = Id();
+			const propsA = { id, key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
+			const propsB = { id, key: 200, values:[ {name: 'abc'},{name: 'dif'}] } satisfies Props;
+
+			const a = EntityExample.create(propsA).value();
+			const b = EntityExample.create(propsB).value();
+
+			expect(a.isEqual(b)).toBeFalsy();
+		});
+
+		it("should not to be equal if id is different", () => {
+
+			const propsA = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
+			const propsB = { key: 200, values:[ {name: 'abc'},{name: 'dif'}] } satisfies Props;
+
+			const a = EntityExample.create(propsA).value();
+			const b = EntityExample.create(propsB).value();
+
+			expect(a.isEqual(b)).toBeFalsy();
 		});
 	})
 });

--- a/tests/core/value-object.spec.ts
+++ b/tests/core/value-object.spec.ts
@@ -1,4 +1,4 @@
-import { Class, ID, Result, ValueObject } from "../../lib/core";
+import { Class, ID, Ok, Result, ValueObject } from "../../lib/core";
 import { ICommand, IPropsValidation, IResult } from "../../lib/types";
 
 describe('value-object', () => {
@@ -531,5 +531,42 @@ describe('value-object', () => {
 	
 			expect(result.value().get('value')).toBe('change_value');
 		})
+	});
+
+	describe('compare', () => {
+
+		interface Props {
+			value: string;
+		}
+		class Exam extends ValueObject<Props> {
+			private constructor(props: Props){
+				super(props)
+			}
+
+			public static create(props: Props): Result<Exam> {
+				return Ok(new Exam(props));
+			}
+		};
+
+		it('should to be equal another instance', () => {
+			const a = Exam.create({ value : "hello there" }).value();
+			const b = Exam.create({ value : "hello there" }).value();
+
+			expect(a.isEqual(b)).toBeTruthy();
+		});
+
+		it('should to be equal another instance', () => {
+			const a = Exam.create({ value : "hello there" }).value();
+			const b = a.clone().value();
+
+			expect(a.isEqual(b)).toBeTruthy();
+		});
+
+		it('should not to be equal another instance', () => {
+			const a = Exam.create({ value : "hello there 1" }).value();
+			const b = Exam.create({ value : "hello there 2" }).value();
+
+			expect(a.isEqual(b)).toBeFalsy();
+		});
 	})
 });


### PR DESCRIPTION
### 1.16.0 - 2022-01-12

### Added

- Entity: added method `isEqual` to compare current instance with another one.
- ValueObject: added method `isEqual` to compare current instance with another one.

#27 

### Example

```ts

// entity
class EntityExample extends Entity<Props>{
	private constructor(props: Props) {
		super(props)
	}

	public static create(props: Props): Result<EntityExample> {
		return Ok(new EntityExample(props));
	}
}

const a = EntityExample.create({...props, id }).value();
const b = EntityExample.create({...props, id}).value();

console.log(a.isEqual(b));

> true

// ----------------

// value object
class Exam extends ValueObject<Props> {
	private constructor(props: Props){
		super(props)
	}

	public static create(props: Props): Result<Exam> {
		return Ok(new Exam(props));
	}
};

const a = Exam.create({ value : "hello there" }).value();
const b = Exam.create({ value : "hello there" }).value();

console.log(a.isEqual(b));

> true

```
