### PR TITLE
Refactor/set clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 1.17.0 - 2022-01-21
+
+### Changed
+
+- ValueObject, Entity, Aggregate: `clone` method now returns an instance of value object instead `Result`
+- ValueObject, Entity, Aggregate: `set` and `change` method now returns `true` if the value has changed and returns `false` if the value has not changed.
+
 ---
 
 ### 1.16.3 - 2022-01-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- ValueObject, Entity, Aggregate: `clone` method now returns an instance of value object instead `Result`
+- ValueObject, Entity, Aggregate: `clone` method now returns an instance instead `Result`
 - ValueObject, Entity, Aggregate: `set` and `change` method now returns `true` if the value has changed and returns `false` if the value has not changed.
 
 ---

--- a/example/index.ts
+++ b/example/index.ts
@@ -12,6 +12,16 @@ export class MyValueObject extends ValueObject<Props>{
 		return false;
 	}
 
+	sum(value: number): number {
+		const current  = this.props.value;
+		return this.util.number(current).sum(value);
+	}
+
+	isEven(): boolean {
+		const current  = this.props.value;
+		return this.validator.number(current).isEven();
+	}
+
 	public static create(props: Props): Result<MyValueObject> {
 		return Result.Ok(new MyValueObject(props));
 	}
@@ -21,5 +31,9 @@ const result = MyValueObject.create({ value: 42 });
 
 assert.equal(result.isOk(), true, 'the result is failure');
 assert.equal(result.value().get('value'), 42, 'the value is not 42');
+assert.equal(result.value().sum(1), 43, 'the value is not 43');
+assert.equal(result.value().isEven(), true, 'the value is even');
 
-result.value().set('value').to(20);
+// validation is set to false
+const changed = result.value().set('value').to(20);
+assert.equal(changed, false, 'value changed');

--- a/lib/core/aggregate.ts
+++ b/lib/core/aggregate.ts
@@ -42,9 +42,9 @@ import Result from "./result";
 	 * @param event Event to be dispatched
 	 * @param replace 'REPLACE_DUPLICATED' option to remove old event with the same name and id
 	 */
-	addEvent(event: IHandle<Aggregate<Props>>, replace?: IReplaceOptions): void {
+	addEvent(event: IHandle<IAggregate<Props>>, replace?: IReplaceOptions): void {
 		const doReplace = replace === 'REPLACE_DUPLICATED';
-		DomainEvents.addEvent({ event: new DomainEvent(this, event), replace: doReplace });
+		DomainEvents.addEvent<Props>({ event: new DomainEvent(this, event), replace: doReplace });
 	}
 
 	/**

--- a/lib/core/entity.ts
+++ b/lib/core/entity.ts
@@ -82,13 +82,11 @@ import Result from "./result";
 	 * @summary if not provide an id a new one will be generated.
 	 * @returns new Entity instance.
 	 */
-	clone(): IResult<Entity<Props>> {
+	clone(): Entity<Props> {
 		const instance = Reflect.getPrototypeOf(this);
-		if (!instance) return Result.fail('Could not get entity instance');
 		const args = [this.props, this.config];
-		const entity = Reflect.construct(instance.constructor, args);
-		if (entity instanceof Entity) return Result.Ok(entity);
-		return Result.fail('Could not create instance of entity');
+		const entity = Reflect.construct(instance!.constructor, args);
+		return entity
 	}
 
 

--- a/lib/core/events.ts
+++ b/lib/core/events.ts
@@ -11,7 +11,7 @@ import Iterator from "./iterator";
 	 * @description Add event to state.
 	 * @param param event to be added.
 	 */
-	public static addEvent({ event, replace }: IEvent<IAggregate<any>>) {
+	public static addEvent<T = any>({ event, replace }: IEvent<IAggregate<T>>) {
 		const target = Reflect.getPrototypeOf(event.callback);
 		const eventName = event.callback?.eventName ?? target?.constructor.name as string;
 		if (!!replace) DomainEvents.deleteEvent({ eventName, id: event.aggregate.id });

--- a/lib/core/getters-and-setters.ts
+++ b/lib/core/getters-and-setters.ts
@@ -204,25 +204,25 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 			 * @param validation function to validate the value before apply. The value will be applied only if to pass on validation.
 			 * @example 
 			 * (value: PropValue) => boolean;
-			 * @returns instance of this.
+			 * @returns returns "true" if the value has changed and returns "false" if the value has not changed.
 			 */
-			to: (value: Props[Key], validation?: (value: Props[Key]) => boolean): GettersAndSetters<Props> => {
+			to: (value: Props[Key], validation?: (value: Props[Key]) => boolean): boolean => {
 				const instance = Reflect.getPrototypeOf(this);
 				if (this.config.disableSetters) {
 					console.log(`Trying to set value: "${value}" for key: "${String(key)}" but, %c the setters are deactivated on ${instance?.constructor.name}`);
-					return this
+					return false;
 				};
 				if (typeof validation === 'function') {
 					if (!validation(value)) {
 						console.log(`Trying to set value: "${value}" for key: "${String(key)}" but failed validation on ${instance?.constructor.name}`);
-						return this
+						return false;
 					};
 				}
 
 				const canUpdate = this.validation(value, key);
 				if (!canUpdate) {
 					console.log(`Trying to set value: "${value}" for key: "${String(key)}" but failed validation on ${instance?.constructor.name}`);
-					return this;
+					return false;
 				}
 				
 				if (key === 'id' && this.parentName === 'Entity') {
@@ -233,7 +233,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 							this['props'] = Object.assign({}, { ...this['props'] }, { updatedAt: new Date() });
 						}
 						this.snapshotSet();
-						return this;
+						return true;
 					}
 					if (this.validator.isID(value)) {
 						this['_id'] = value as unknown as ID<string>;
@@ -242,7 +242,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 							this['props'] = Object.assign({}, { ...this['props'] }, { updatedAt: new Date() });
 						}
 						this.snapshotSet();
-						return this;
+						return true;
 					}
 				}
 				this.props[key] = value;
@@ -250,7 +250,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 					this['props'] = Object.assign({}, { ...this['props'] }, { updatedAt: new Date() });
 				}
 				this.snapshotSet();
-				return this;
+				return true;
 			}
 		}
 	}
@@ -259,25 +259,25 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 	 * @param key the property you want to set.
 	 * @param value the value to apply to the key.
 	 * @param validation function to validate the value before apply. The value will be applied only if to pass.
-	 * @returns instance of own class.
+	 * @returns returns "true" if the value has changed and returns "false" if the value has not changed.
 	 */
-	change<Key extends keyof Props>(key: Key, value: Props[Key], validation?: (value: Props[Key]) => boolean) {
+	change<Key extends keyof Props>(key: Key, value: Props[Key], validation?: (value: Props[Key]) => boolean): boolean {
 		const instance = Reflect.getPrototypeOf(this);
 		if (this.config.disableSetters) {
 			console.log(`Trying to set value: "${value}" for key: "${String(key)}" but the setters are deactivated on ${instance?.constructor.name}`);
-			return this
+			return false;
 		};
 
 		if (typeof validation === 'function') {
 			if (!validation(value)) {
 				console.log(`Trying to set value: "${value}" for key: "${String(key)}" but failed validation on ${instance?.constructor.name}`);
-				return this
+				return false;
 			};
 		}
 		const canUpdate = this.validation(value, key);
 		if (!canUpdate) {
 			console.log(`Trying to set value: "${value}" for key: "${String(key)}" but failed validation on ${instance?.constructor.name}`);
-			return this;
+			return false;
 		}
 		if (key === 'id' && this.parentName === 'Entity') {
 			if (this.validator.isString(value) || this.validator.isNumber(value)) {
@@ -287,7 +287,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 					this['props'] = Object.assign({}, { ...this['props'] }, { updatedAt: new Date() });
 				}
 				this.snapshotSet();
-				return this;
+				return true;
 			}
 			if (this.validator.isID(value)) {
 				this['_id'] = value as unknown as ID<string>;
@@ -296,7 +296,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 					this['props'] = Object.assign({}, { ...this['props'] }, { updatedAt: new Date() });
 				}
 				this.snapshotSet();
-				return this;
+				return true;
 			}
 		}
 		this.props[key] = value;
@@ -304,7 +304,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 			this['props'] = Object.assign({}, { ...this['props'] }, { updatedAt: new Date() });
 		}
 		this.snapshotSet();
-		return this;
+		return true;
 	}
 
 	/**

--- a/lib/core/value-object.ts
+++ b/lib/core/value-object.ts
@@ -33,13 +33,11 @@ export class ValueObject<Props> extends GettersAndSetters<Props> implements IVal
 	 * @description Get an instance copy.
 	 * @returns a new instance of value object.
 	 */
-	clone(): IResult<ValueObject<Props>> {
+	clone(): ValueObject<Props> {
 		const instance = Reflect.getPrototypeOf(this);
-		if (!instance) return Result.fail('Could not get value object instance');
 		const args = [this.props, this.config];
-		const obj = Reflect.construct(instance.constructor, args);
-		if (obj instanceof ValueObject) return Result.Ok(obj);
-		return Result.fail('Could not create instance of value object');
+		const obj = Reflect.construct(instance!.constructor, args);
+		return obj;
 	}
 
 	/**
@@ -56,9 +54,10 @@ export class ValueObject<Props> extends GettersAndSetters<Props> implements IVal
 	 * @deprecated do not use `set` function to change `value-object` state. 
 	 * @access create a new instance instead
 	 * @method `set` function will be removed for `value-objects` in future version.
+	 * returns "true" if the value has changed and returns "false" if the value has not changed.
 	 */
 	set<Key extends keyof Props>(key: Key): { 
-		to: (value: Props[Key], validation?: ((value: Props[Key]) => boolean) | undefined) => GettersAndSetters<Props>; 
+		to: (value: Props[Key], validation?: ((value: Props[Key]) => boolean) | undefined) => boolean; 
 	} {
 		return super.set(key);
 	}
@@ -69,7 +68,7 @@ export class ValueObject<Props> extends GettersAndSetters<Props> implements IVal
 	 * @access create a new instance instead
 	 * @method `change` function will be removed for `value-objects` in future version.
 	 */
-	change<Key extends keyof Props>(key: Key, value: Props[Key], validation?: ((value: Props[Key]) => boolean) | undefined): this {
+	change<Key extends keyof Props>(key: Key, value: Props[Key], validation?: ((value: Props[Key]) => boolean) | undefined): boolean {
 		return super.change(key, value, validation);
 	}
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -230,23 +230,21 @@ export interface IEntity<Props> {
 	get id(): UID<string>;
 	hashCode(): UID<string>;
 	isNew(): boolean;
-	clone(): IResult<IEntity<Props>>;
+	clone(): IEntity<Props>;
 }
 
 export interface IValueObject<Props> {
-	clone(): IResult<IValueObject<Props>>;
+	clone(): IValueObject<Props>;
 	toObject<T>(adapter?: IAdapter<this, T>): T;
 }
-
-
 
 export interface IGettersAndSetters<Props> {
 	validation<Key extends keyof Props>(value: Props[Key], key: Key): boolean;
 	get<Key extends keyof Props>(key: Key): Props[Key];
 	set<Key extends keyof Props>(key: Key): {
-		to: (value: Props[Key], validation?: (value: Props[Key]) => boolean) => IGettersAndSetters<Props>
+		to: (value: Props[Key], validation?: (value: Props[Key]) => boolean) => boolean;
 	};
-	change<Key extends keyof Props>(key: Key, value: Props[Key], validation?: (value: Props[Key]) => boolean): IGettersAndSetters<Props>;
+	change<Key extends keyof Props>(key: Key, value: Props[Key], validation?: (value: Props[Key]) => boolean): boolean;
 	history(): IPublicHistory<Props>;
 }
 
@@ -255,7 +253,7 @@ export interface IAggregate<Props> {
 	get id(): UID<string>;
 	hashCode(): UID<string>;
 	isNew(): boolean;
-	clone(): IResult<IEntity<Props>>;
+	clone(): IEntity<Props>;
 	addEvent(event: IHandle<IAggregate<Props>>, replace?: IReplaceOptions): void;
 	deleteEvent(eventName: string): void;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.16.3",
+	"version": "1.17.0",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/tests/core/aggragate.spec.ts
+++ b/tests/core/aggragate.spec.ts
@@ -85,11 +85,17 @@ describe('aggregate', () => {
 			expect(agg.value().get('name')).toBe('Jane Doe');
 			expect(agg.value().get('age')).toBe(23);
 
-			agg.value().set('age').to(18).set('name').to('Anne');
+			const setAge = agg.value().set('age').to(18);
+			const setName = agg.value().set('name').to('Anne');
+			expect(setAge).toBeTruthy();
+			expect(setName).toBeTruthy();
 			expect(agg.value().get('age')).toBe(18);
 			expect(agg.value().get('name')).toBe('Anne');
 
-			agg.value().change('age', 21).change('name', 'Louse');
+			const changedAge = agg.value().change('age', 21);
+			const changedName = agg.value().change('name', 'Louse');
+			expect(changedName).toBeTruthy();
+			expect(changedAge).toBeTruthy();
 			expect(agg.value().get('age')).toBe(21);
 			expect(agg.value().get('name')).toBe('Louse');
 		});
@@ -178,17 +184,19 @@ describe('aggregate', () => {
 				.set('age')
 				.to(age18);
 
-			expect(result.get('age').get('value')).toBe(18);
+			expect(result).toBeTruthy();
+
+			expect(user.get('age').get('value')).toBe(18);
 
 			expect(user.history().count()).toBe(2);
 
 			user.history().back();
 
-			expect(result.get('age').get('value')).toBe(21);
+			expect(user.get('age').get('value')).toBe(21);
 
 			user.history().forward();
 
-			expect(result.get('age').get('value')).toBe(18);
+			expect(user.get('age').get('value')).toBe(18);
 		});
 
 	});

--- a/tests/core/entity.spec.ts
+++ b/tests/core/entity.spec.ts
@@ -63,8 +63,8 @@ describe("entity", () => {
 
 		it('should clone entity with success and keep the same id', () => {
 			const clone = entity.value().clone();
-			expect(clone.value().id.value()).toBe(id);
-			expect(clone.value().get('key')).toBe('value');
+			expect(clone.id.value()).toBe(id);
+			expect(clone.get('key')).toBe('value');
 		});
 
 		it('should snapshot entity', () => {
@@ -181,7 +181,7 @@ describe("entity", () => {
 			const props = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
 
 			const a = EntityExample.create({...props, id}).value();
-			const b = a.clone().value();
+			const b = a.clone();
 			
 			expect(a.isEqual(b)).toBeTruthy();
 		});
@@ -192,7 +192,7 @@ describe("entity", () => {
 			const props = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
 
 			const a = EntityExample.create({...props, id}).value();
-			const b = a.clone().value();
+			const b = a.clone();
 			b.set('key').to(201);
 			
 			expect(a.isEqual(b)).toBeFalsy();

--- a/tests/core/getters.spec.ts
+++ b/tests/core/getters.spec.ts
@@ -42,31 +42,36 @@ describe('getters and setters', () => {
 
 	it('should change value with success', () => {
 		const gettersAndSetters = new GettersAndSetters<{ key: string }>({ key: 'value' }, 'ValueObject');
-		expect(gettersAndSetters.change('key', 'changed').get('key')).toBe('changed');
+		expect(gettersAndSetters.change('key', 'changed')).toBeTruthy();
+		expect(gettersAndSetters.get("key")).toBe('changed');
 	});
 
 	it('should set value with success', () => {
 		const gettersAndSetters = new GettersAndSetters<{ key: string }>({ key: 'value' }, 'ValueObject');
-		expect(gettersAndSetters.set('key').to('changed').get('key')).toBe('changed');
+		expect(gettersAndSetters.set('key').to('changed')).toBeTruthy();
+		expect(gettersAndSetters.get("key")).toBe('changed');
 	});
 
 	it('should do not set if do not pass on validation', () => {
 		const gettersAndSetters = new GettersAndSetters<{ key: string }>({ key: 'value' }, 'ValueObject');
 		const validation = (value: string) => value !== 'changed';
-		expect(gettersAndSetters.change('key', 'changed', validation).get('key')).toBe('value');
-		expect(gettersAndSetters.change('key', 'change', validation).get('key')).toBe('change');
+		expect(gettersAndSetters.change('key', 'changed', validation)).toBeFalsy();
+		expect(gettersAndSetters.change('key', 'change', validation)).toBeTruthy();
+		expect(gettersAndSetters.get("key")).toBe('change');
 	});
 
 	it('should do not change if is deactivate', () => {
 		const gettersAndSetters = new GettersAndSetters<{ key: string }>({ key: 'value' }, 'ValueObject', { disableSetters: true });
-		expect(gettersAndSetters.change('key', 'changed').get('key')).toBe('value');
+		expect(gettersAndSetters.change('key', 'changed')).toBeFalsy();
+		expect(gettersAndSetters.get("key")).toBe('value');
 	});
 
 	it('should do not set if do not pass on validation', () => {
 		const gettersAndSetters = new GettersAndSetters<{ key: string }>({ key: 'value' }, 'ValueObject');
 		const validation = (value: string) => value !== 'changed';
-		expect(gettersAndSetters.set('key').to('changed', validation).get('key')).toBe('value');
-		expect(gettersAndSetters.set('key').to('change', validation).get('key')).toBe('change');
+		expect(gettersAndSetters.set('key').to('changed', validation)).toBeFalsy();
+		expect(gettersAndSetters.set('key').to('change', validation)).toBeTruthy();
+		expect(gettersAndSetters.get("key")).toBe('change');
 	});
 
 });

--- a/tests/core/value-object.spec.ts
+++ b/tests/core/value-object.spec.ts
@@ -225,7 +225,7 @@ describe('value-object', () => {
 
 			const result = sample.value().clone();
 
-			expect(sample.value().toObject()).toEqual(result.value().toObject())
+			expect(sample.value().toObject()).toEqual(result.toObject())
 		});
 
 		it('should navigate for history', () => {
@@ -557,7 +557,7 @@ describe('value-object', () => {
 
 		it('should to be equal another instance', () => {
 			const a = Exam.create({ value : "hello there" }).value();
-			const b = a.clone().value();
+			const b = a.clone();
 
 			expect(a.isEqual(b)).toBeTruthy();
 		});


### PR DESCRIPTION
### 1.17.0 - 2022-01-21

### Changed

- ValueObject, Entity, Aggregate: `clone` method now returns an instance instead `Result`
- ValueObject, Entity, Aggregate: `set` and `change` method now returns `true` if the value has changed and returns `false` if the value has not changed.