### PR TITLE
Fix/calc precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,75 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-### 1.17.0 - 2022-01-21
+---
 
-### Changed
+### [1.17.1] - 2022-01-27
 
-- ValueObject, Entity, Aggregate: `clone` method now returns an instance instead `Result`
-- ValueObject, Entity, Aggregate: `set` and `change` method now returns `true` if the value has changed and returns `false` if the value has not changed.
+### Fix
+
+- utils.numer: fix precision on calculation and infinity case
+
+```ts
+
+// Example using fractionDigits
+// Default fractionDigits is 5
+
+util.number(0.02).divideBy(0.04, { fractionDigits: 4 });
+
+> 0.7777
+
+```
+
+```ts
+
+// Example Infinity case now returns 0
+// 0 / 1 = Infinity
+
+util.number(0).divideBy(1);
+
+> 0
+
+```
 
 ---
 
-### 1.16.3 - 2022-01-20
+### [1.17.0] - 2022-01-21
+
+### Changed
+- Rename methods
+- Change payload
+
+### Breaking Change
+- ValueObject, Entity, Aggregate: `clone` method now returns an instance instead `Result`
+- ValueObject, Entity, Aggregate: `set` and `change` method now returns `true` if the value has changed and returns `false` if the value has not changed.
+
+```ts
+
+// Example using set now
+
+const changed = user.set("name").to(age);
+
+console.log(changed);
+
+> true
+
+```
+
+```ts
+
+// Example using clone now
+
+const copy = user.clone();
+
+console.log(copy.get("name").get("value"))
+
+> "Jane Doe"
+
+```
+
+---
+
+### [1.16.3] - 2022-01-20
 
 ### Added
 
@@ -21,7 +80,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-### 1.16.2 - 2022-01-19
+### [1.16.2] - 2022-01-19
 
 ### Added
 
@@ -30,7 +89,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-### 1.16.1 - 2022-01-18
+### [1.16.1] - 2022-01-18
 
 ### Added
 
@@ -39,7 +98,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-### 1.16.0 - 2022-01-12
+### [1.16.0] - 2022-01-12
 
 ### Added
 
@@ -47,21 +106,21 @@ All notable changes to this project will be documented in this file.
 - ValueObject: added method `isEqual` to compare current instance with another one. [Issue 27](https://github.com/4lessandrodev/rich-domain/issues/27)
 
 ---
-### 1.15.2 - 2022-01-05
+### [1.15.2] - 2022-01-05
 
 ### Fixed
 
 - toObject method on entity: fix error on process simple object on entity [issue #25](https://github.com/4lessandrodev/rich-domain/issues/25)
 
 ---
-### 1.15.1 - 2022-01-03
+### [1.15.1] - 2022-01-03
 
 ### Changed
 
 - node version: update requirements. node version required >=16 and < 19
 
 ---
-### 1.15.0 - 2022-12-25
+### [1.15.0] - 2022-12-25
 
 ### Changed
 
@@ -78,7 +137,7 @@ All notable changes to this project will be documented in this file.
 The function still works, but it is marked as deprecated. show warning if using.
 
 ---
-### 1.14.6 - 2022-11-27
+### [1.14.6] - 2022-11-27
 
 ### Fixed
 
@@ -86,7 +145,7 @@ The function still works, but it is marked as deprecated. show warning if using.
 - Now its possible to convert entity on aggregate
 
 ---
-### 1.14.5 - 2022-11-25
+### [1.14.5] - 2022-11-25
 
 ### Fixed
 
@@ -98,14 +157,14 @@ The function still works, but it is marked as deprecated. show warning if using.
 - dispatchAll: added fn to dispatch all event by aggregate id
 
 ---
-### 1.14.4 - 2022-11-22
+### [1.14.4] - 2022-11-22
 
 ### Changed
 
 - Types: update types for Result
 
 ---
-### 1.14.3 - 2022-11-22
+### [1.14.3] - 2022-11-22
 
 ### Changed
 
@@ -116,21 +175,21 @@ The function still works, but it is marked as deprecated. show warning if using.
 - Types: added Payload type as Result type
 
 ---
-### 1.14.2 - 2022-11-22
+### [1.14.2] - 2022-11-22
 
 ### Added
 
 - validator: added method to validate if all chars in string is number
 
 ---
-### 1.14.1 - 2022-10-03
+### [1.14.1] - 2022-10-03
 
 ### Updated
 
 - result: ensure result props to be read only
 
 ---
-### 1.14.0 - 2022-09-27
+### [1.14.0] - 2022-09-27
 
 ### Change
 
@@ -208,7 +267,7 @@ interface MetaData {
 return Fail<string, MetaData>('payload', { arg: 'sample' })
 ```
 ---
-### 1.13.0 - 2022-09-26
+### [1.13.0] - 2022-09-26
 
 ### Added
 
@@ -216,14 +275,14 @@ return Fail<string, MetaData>('payload', { arg: 'sample' })
 - feat: implement function Ok
 
 ---
-### 1.12.0 - 2022-09-14
+### [1.12.0] - 2022-09-14
 
 ### Fixed
 
 fix: implement support for native randomUUID
 
 ---
-### 1.11.2 - 2022-09-03
+### [1.11.2] - 2022-09-03
 
 ### Changed
 
@@ -235,7 +294,7 @@ chore: updated dependencies
 fix: update some types error on update typescript
 
 ---
-### 1.11.1 - 2022-08-14
+### [1.11.1] - 2022-08-14
 
 ### Added
 
@@ -246,7 +305,7 @@ docs: added full documentation to readme
 
 ---
 
-### 1.11.0 - 2022-08-10
+### [1.11.0] - 2022-08-10
 
 ### Changed
 
@@ -265,7 +324,7 @@ Now second arg is optional. The key is not required
 ```
 
 ---
-### 1.10.0 - 2022-08-07
+### [1.10.0] - 2022-08-07
 
 ### Added
 
@@ -299,7 +358,7 @@ age.value().get('value') // 21
 
 ---
 
-### 1.9.0-beta - 2022-08-06
+### [1.9.0]-beta - 2022-08-06
 
 ### Change
 

--- a/README.md
+++ b/README.md
@@ -890,13 +890,7 @@ console.log(originalName.value());
 
 const clone = originalName.clone();
 
-console.log(clone.isOk());
-
-> true
-
-const clonedName = clone.value();
-
-console.log(clonedName.value());
+console.log(clone);
 
 > "Sammy"
 
@@ -1150,11 +1144,15 @@ const result = Name.create('Larry');
 
 const newName = result.value();
 
-user.change("name", newName);
+const changed = user.change("name", newName);
 
 console.log(user.get("name").value());
 
 > "Larry"
+
+console.log(changed);
+
+> true
 
 ```
 
@@ -1250,17 +1248,19 @@ const user = result.value();
 
  const clonedUser = user.clone();
 
- const newUser = clonedUser.value();
-
  const newNameResult = Name.create('Luke');
 
  const newName = newNameResult.value();
 
- clonedUser.set('name').to(newName);
+ const changed = clonedUser.set('name').to(newName);
 
  console.log(user.get('name').value());
 
  > "James"
+
+ console.log(changed);
+
+ > true
 
  console.log(clonedUser.get('name').value());
 

--- a/lib/core/id.ts
+++ b/lib/core/id.ts
@@ -152,4 +152,5 @@ export class ID<T = string> implements UID<T> {
 
 export default ID;
 export const id = ID;
+export const Uid = ID.create;
 export const Id = ID.create;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,3 +13,6 @@ export * from './utils/to-decimal-number.util';
 export * from './utils/to-long-number.util';
 export * from './utils/increment-time.util';
 export * from './utils/decrement-time.util';
+export * from './utils/to-precision.util';
+export * from './utils/is-nan.util';
+export * from './utils/ensure-number';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -288,3 +288,5 @@ export const ONE_DAY = ONE_HOUR * 24;
 export const ONE_WEEK = ONE_DAY * 7;
 export const ONE_MONTH = ONE_DAY * 30;
 export const ONE_YEAR = ONE_DAY * 365;
+
+export type CalcOpt = { fractionDigits: number };

--- a/lib/utils/divide-number.util.ts
+++ b/lib/utils/divide-number.util.ts
@@ -1,22 +1,25 @@
+import EnsureNumber from "./ensure-number";
+import IsNaN from "./is-nan.util";
 import Float from "./normalize-number.util";
 import ToLong from "./to-long-number.util";
+import ToPrecision from "./to-precision.util";
 
-export const Divide = (valueA: number, valueB: number): number => {
+export const Divide = (valueA: number, valueB: number, precision = 5): number => {
     const isValueAnumber = typeof valueA === 'number';
     const isValueBnumber = typeof valueB === 'number';
     const isBothNumber = isValueAnumber && isValueBnumber;
 
     if(!isBothNumber){
-        const isNaNValueA = isNaN(valueA);
-        const isNaNValueB = isNaN(valueB);
+        const isNaNValueA = IsNaN(valueA);
+        const isNaNValueB = IsNaN(valueB);
         const isBothNaN = isNaNValueA && isNaNValueB;
         if(isBothNaN || isNaNValueA || isNaNValueB) return 0;
-        if(typeof valueA === 'string' && typeof valueB === 'string') return Float((ToLong(Float(valueA)) / ToLong(Float(valueB))));
-        if(typeof valueA === 'string' && typeof valueB === 'number') return Float((ToLong(Float(valueA)) / ToLong(valueB)));
-        if(typeof valueB === 'string' && typeof valueA === 'number') return Float((ToLong(valueA) / ToLong(Float(valueB))));
+        const result = ToPrecision(Float((ToLong(Float(valueA)) / ToLong(Float(valueB)))), precision);
+        return EnsureNumber(result);
     }
 
-    return Float((ToLong(valueA) / ToLong(valueB)));
+    const result = ToPrecision(Float((ToLong(valueA) / ToLong(valueB))), precision);
+    return EnsureNumber(result);
 }
 
 export default Divide;

--- a/lib/utils/ensure-number.ts
+++ b/lib/utils/ensure-number.ts
@@ -1,0 +1,8 @@
+import IsNaN from "./is-nan.util";
+
+export const EnsureNumber = (value: number): number => {
+    if(IsNaN(value) || value === Infinity) return 0;
+    return value;
+}
+
+export default EnsureNumber;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -11,3 +11,6 @@ export * from './to-decimal-number.util';
 export * from './to-long-number.util';
 export * from './increment-time.util';
 export * from './decrement-time.util';
+export * from './to-precision.util';
+export * from './is-nan.util';
+export * from './ensure-number';

--- a/lib/utils/is-nan.util.ts
+++ b/lib/utils/is-nan.util.ts
@@ -1,0 +1,5 @@
+export const IsNaN = (value: string | number) : boolean => {
+    return isNaN(parseFloat(String(value)));
+}
+
+export default IsNaN;

--- a/lib/utils/multiply-number.util.ts
+++ b/lib/utils/multiply-number.util.ts
@@ -1,28 +1,25 @@
+import EnsureNumber from "./ensure-number";
+import IsNaN from "./is-nan.util";
 import Float from "./normalize-number.util";
 import ToDecimal from "./to-decimal-number.util";
 import ToLong from "./to-long-number.util";
+import ToPrecision from "./to-precision.util";
 
-export const Multiply = (valueA: number, valueB: number): number => {
+export const Multiply = (valueA: number, valueB: number, precision = 5): number => {
     const isValueAnumber = typeof valueA === 'number';
     const isValueBnumber = typeof valueB === 'number';
     const isBothNumber = isValueAnumber && isValueBnumber;
 
     if(!isBothNumber){
-        const isNaNValueA = isNaN(valueA);
-        const isNaNValueB = isNaN(valueB);
+        const isNaNValueA = IsNaN(valueA);
+        const isNaNValueB = IsNaN(valueB);
         const isBothNaN = isNaNValueA && isNaNValueB;
         if(isBothNaN || isNaNValueA || isNaNValueB) return 0;
-        if(typeof valueA === 'string' && typeof valueB === 'string') {
-            return ToDecimal(Float(ToDecimal(ToLong(Float(valueA)) * ToLong(Float(valueB)))));
-        }
-        if(typeof valueA === 'string' && typeof valueB === 'number'){
-            return ToDecimal(Float(ToDecimal(ToLong(Float(valueA)) * ToLong(valueB))));
-        }
-        if(typeof valueB === 'string' && typeof valueA === 'number'){
-            return ToDecimal(Float(ToDecimal(ToLong(valueA) * ToLong(Float(valueB)))));
-        }
+        const result = ToPrecision(ToDecimal(Float(ToDecimal(ToLong(Float(valueA)) * ToLong(Float(valueB))))), precision);
+        return EnsureNumber(result);
     }
-    return ToDecimal(Float(ToDecimal(ToLong(valueA) * ToLong(valueB))));
+    const result = ToPrecision(ToDecimal(Float(ToDecimal(ToLong(valueA) * ToLong(valueB)))), precision);
+    return EnsureNumber(result);
 }
 
 export default Multiply;

--- a/lib/utils/normalize-number.util.ts
+++ b/lib/utils/normalize-number.util.ts
@@ -1,6 +1,8 @@
+import IsNaN from "./is-nan.util";
+
 export const Float = (value: number): number => {
-    if(typeof value === 'string' && !isNaN(value)) return parseFloat(value);
-    if(typeof value === 'number') return parseFloat(value.toFixed(5));
+    if(typeof value === 'string' && !IsNaN(value)) return parseFloat(value);
+    if(typeof value === 'number') return value;
     return 0;
 }
 

--- a/lib/utils/subtract-number.util.ts
+++ b/lib/utils/subtract-number.util.ts
@@ -1,24 +1,27 @@
+import EnsureNumber from "./ensure-number";
+import IsNaN from "./is-nan.util";
 import Float from "./normalize-number.util";
 import ToDecimal from "./to-decimal-number.util";
 import ToLong from "./to-long-number.util";
+import ToPrecision from "./to-precision.util";
 
-export const Subtract = (valueA: number, valueB: number): number => {
+export const Subtract = (valueA: number, valueB: number, precision = 5): number => {
     const isValueAnumber = typeof valueA === 'number';
     const isValueBnumber = typeof valueB === 'number';
     const isBothNumber = isValueAnumber && isValueBnumber;
 
     if(!isBothNumber){
-        const isNaNValueA = isNaN(valueA);
-        const isNaNValueB = isNaN(valueB);
+        const isNaNValueA = IsNaN(valueA);
+        const isNaNValueB = IsNaN(valueB);
         const isBothNaN = isNaNValueA && isNaNValueB;
         if(isBothNaN) return 0;
         if(isNaNValueA) return Float(valueB) * -1;
         if(isNaNValueB) return Float(valueA);
-        if(typeof valueA === 'string' && typeof valueB === 'string') return Float(ToDecimal(ToLong(Float(valueA)) - ToLong(Float(valueB))));
-        if(typeof valueA === 'string' && typeof valueB === 'number') return Float(ToDecimal(ToLong(Float(valueA)) - ToLong(valueB)));
-        if(typeof valueB === 'string' && typeof valueA === 'number') return Float(ToDecimal(ToLong(valueA) - ToLong(Float(valueB))));
+        const result = ToPrecision(Float(ToDecimal(ToLong(Float(valueA)) - ToLong(Float(valueB)))), precision);
+        return EnsureNumber(result);
     }
-    return Float(ToDecimal(ToLong(valueA) - ToLong(valueB)));
+    const result = ToPrecision(Float(ToDecimal(ToLong(valueA) - ToLong(valueB))), precision);
+    return EnsureNumber(result);
 }
 
 export default Subtract;

--- a/lib/utils/sum-number.util.ts
+++ b/lib/utils/sum-number.util.ts
@@ -1,24 +1,27 @@
+import EnsureNumber from "./ensure-number";
+import IsNaN from "./is-nan.util";
 import Float from "./normalize-number.util";
 import ToDecimal from "./to-decimal-number.util";
 import ToLong from "./to-long-number.util";
+import ToPrecision from "./to-precision.util";
 
-export const Sum = (valueA: number, valueB: number): number => {
+export const Sum = (valueA: number, valueB: number, precision = 5): number => {
     const isValueAnumber = typeof valueA === 'number';
     const isValueBnumber = typeof valueB === 'number';
     const isBothNumber = isValueAnumber && isValueBnumber;
 
     if(!isBothNumber){
-        const isNaNValueA = isNaN(valueA);
-        const isNaNValueB = isNaN(valueB);
+        const isNaNValueA = IsNaN(valueA);
+        const isNaNValueB = IsNaN(valueB);
         const isBothNaN = isNaNValueA && isNaNValueB;
         if(isBothNaN) return 0;
         if(isNaNValueA) return Float(valueB);
         if(isNaNValueB) return Float(valueA);
-        if(typeof valueA === 'string' && typeof valueB === 'string') return Float(ToDecimal(ToLong(Float(valueA)) + ToLong(Float(valueB))));
-        if(typeof valueA === 'string' && typeof valueB === 'number') return Float(ToDecimal(ToLong(Float(valueA)) + ToLong(valueB)));
-        if(typeof valueB === 'string' && typeof valueA === 'number') return Float(ToDecimal(ToLong(valueA) + ToLong(Float(valueB))));
+        const result = ToPrecision(Float(ToDecimal(ToLong(Float(valueA)) + ToLong(Float(valueB)))), precision);
+        return EnsureNumber(result);
     }
-    return Float(ToDecimal(ToLong(valueA) + ToLong(valueB)));
+    const result = ToPrecision(Float(ToDecimal(ToLong(valueA) + ToLong(valueB))), precision);
+    return EnsureNumber(result);
 }
 
 export default Sum;

--- a/lib/utils/to-decimal-number.util.ts
+++ b/lib/utils/to-decimal-number.util.ts
@@ -1,6 +1,6 @@
 export const ToDecimal = (value: number): number => {
     const isValid = typeof value === 'number';
     if(!isValid) return value;
-    return value / 10;
+    return value / 100;
 }
 export default ToDecimal;

--- a/lib/utils/to-long-number.util.ts
+++ b/lib/utils/to-long-number.util.ts
@@ -1,6 +1,6 @@
 export const ToLong = (value: number): number => {
     const isValid = typeof value === 'number';
     if(!isValid) return value;
-    return value * 10;
+    return value * 100;
 }
 export default ToLong;

--- a/lib/utils/to-precision.util.ts
+++ b/lib/utils/to-precision.util.ts
@@ -1,0 +1,8 @@
+export const ToPrecision = (value: number| string, precision: number): number => {
+    if(typeof value === 'string') return parseFloat(parseFloat(String(value)).toFixed(precision));
+    const int = (Math.trunc(value) * 100);
+    const dec = Number((((value * 100) - (int)) / 100).toPrecision(precision + 3).slice(0, precision + 2));
+    return Number(((int / 100) + dec).toPrecision(String(int).length + 1 + precision));
+}
+
+export default ToPrecision;

--- a/lib/utils/util.ts
+++ b/lib/utils/util.ts
@@ -8,6 +8,7 @@ import Subtract from "./subtract-number.util";
 import Sum from "./sum-number.util";
 import IncrementTime from "./increment-time.util";
 import DecrementTime from "./decrement-time.util";
+import { CalcOpt } from "../types";
 
 export class Utils {
     private static instance: Utils;
@@ -94,31 +95,39 @@ export class Utils {
             /**
              * @description multiply a value for another one.
              * @param value number or string (number)
+             * @param options as object with fractionDigits option
+             * @default fractionDigits 5
              * @returns result as number
              * @sumary If you provide a string NAN (not a number) 0 will be considered as value.
              */
-            multiplyBy: (value: number): number => Multiply(target, value),
+            multiplyBy: (value: number, opt?: CalcOpt): number => Multiply(target, value, opt?.fractionDigits),
             /**
              * @description divide a value for another one.
              * @param value number or string
+             * @param options as object with fractionDigits option
+             * @default fractionDigits 5
              * @returns result as number
              * @sumary If you provide a string NAN (not a number) 0 will be considered as value.
              */
-            divideBy: (value: number): number => Divide(target, value),
+            divideBy: (value: number, opt?: CalcOpt): number => Divide(target, value, opt?.fractionDigits),
             /**
              * @description subtract a value for another one.
              * @param value number or string
+             * @param options as object with fractionDigits option
+             * @default fractionDigits 5
              * @returns result as number
              * @sumary If you provide a string NAN (not a number) 0 will be considered as value.
              */
-            subtract: (value: number): number => Subtract(target, value),
+            subtract: (value: number, opt?: CalcOpt): number => Subtract(target, value, opt?.fractionDigits),
             /**
              * @description sum a value with another one.
              * @param value number or string
+             * @param options as object with fractionDigits option
+             * @default fractionDigits 5
              * @returns result as number
              * @sumary If you provide a string NAN (not a number) 0 will be considered as value.
              */
-            sum: (value: number): number => Sum(target, value)
+            sum: (value: number, opt?: CalcOpt): number => Sum(target, value, opt?.fractionDigits)
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.17.0",
+	"version": "1.17.1",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@types/jest": "^28.1.8",
 		"jest": "^28.1.3",
 		"madge": "^5.0.1",
-		"rimraf": "^4.0.7",
+		"rimraf": "^4.1.2",
 		"ts-jest": "^28.0.5",
 		"ts-node": "^10.8.2",
 		"typescript": "^4.9.3"

--- a/tests/utils/divide-number-util.spec.ts
+++ b/tests/utils/divide-number-util.spec.ts
@@ -45,4 +45,47 @@ describe('divide-number', () => {
         const result = Divide(40, '10' as unknown as number);
         expect(result).toBe(4);
     });
+
+    it('should return 10a / 2 = 5', () => {
+        const result = Divide('10a' as any, 2);
+        expect(result).toBe(5);
+    });
+
+    it('should return 20 / 2a = 10', () => {
+        const result = Divide(20, '2a' as any);
+        expect(result).toBe(10);
+    });
+
+    it('should return 15a / 3a = 10', () => {
+        const result = Divide('15a' as any, '3a' as any);
+        expect(result).toBe(5);
+    });
+
+    it('should implement calc with success', () => {
+        expect.assertions(11);
+        const table: string[] = [];
+        let i = 10;
+        while(i >= 1){
+            const result = Divide(100, i, 9);
+            const expected = Number(String(100 / i).slice(0, 12));
+            table.push(`${100} / ${i} = ${result}`);
+            expect(result).toBe(expected);
+            i--;
+        }
+
+        expect(table).toMatchInlineSnapshot(`
+Array [
+  "100 / 10 = 10",
+  "100 / 9 = 11.111111111",
+  "100 / 8 = 12.5",
+  "100 / 7 = 14.285714285",
+  "100 / 6 = 16.666666666",
+  "100 / 5 = 20",
+  "100 / 4 = 25",
+  "100 / 3 = 33.333333333",
+  "100 / 2 = 50",
+  "100 / 1 = 100",
+]
+`);
+    })
 });

--- a/tests/utils/ensure-number-util.spec.ts
+++ b/tests/utils/ensure-number-util.spec.ts
@@ -1,0 +1,28 @@
+import EnsureNumber from '../../lib/utils/ensure-number';
+
+describe('ensure-number.util', () => {
+    it('should return 0 if Infinity', () => {
+        const result = EnsureNumber(Infinity);
+        expect(result).toBe(0);
+    });
+
+    it('should return 0 if NaN', () => {
+        const result = EnsureNumber(NaN);
+        expect(result).toBe(0);
+    });
+
+    it('should return 0 if NaN', () => {
+        const result = EnsureNumber("INVALID" as any);
+        expect(result).toBe(0);
+    });
+
+    it('should return the value', () => {
+        const result = EnsureNumber(42);
+        expect(result).toBe(42);
+    })
+
+    it('should return the value', () => {
+        const result = EnsureNumber('42' as any);
+        expect(result).toBe('42');
+    })
+})

--- a/tests/utils/is-nan-util.spec.ts
+++ b/tests/utils/is-nan-util.spec.ts
@@ -1,0 +1,18 @@
+import IsNaN from "../../lib/utils/is-nan.util"
+
+describe('is-nan.util', () => {
+    it('should string starts with letters is Nan', () => {
+        const isN = IsNaN('abc123');
+        expect(isN).toBeTruthy();
+    });
+
+    it('should string starts with numbers not is Nan', () => {
+        const isN = IsNaN('123asdv');
+        expect(isN).toBeFalsy();
+    });
+
+    it('should numbers not is Nan', () => {
+        const isN = IsNaN(123);
+        expect(isN).toBeFalsy();
+    });
+});

--- a/tests/utils/multiply-number-util.spec.ts
+++ b/tests/utils/multiply-number-util.spec.ts
@@ -60,4 +60,47 @@ describe('multiply-number', () => {
         const result = Multiply(42, '10.3' as unknown as number);
         expect(result).toBe(432.6);
     });
+
+    it('should return 10a x 2 = 20', () => {
+        const result = Multiply('10a' as any, 2);
+        expect(result).toBe(20);
+    });
+
+    it('should return 20 x 2a = 40', () => {
+        const result = Multiply(20, '2a' as any);
+        expect(result).toBe(40);
+    });
+
+    it('should return 15a x 3a = 45', () => {
+        const result = Multiply('15a' as any, '3a' as any);
+        expect(result).toBe(45);
+    });
+
+    it('should implement calc with success', () => {
+        expect.assertions(11);
+        const table : string[] = [];
+        let i = 10;
+        while(i >= 1){
+            const result = Multiply(100, i, 9);
+            const expected = Number(String(100 * i).slice(0, 12));
+            table.push(`${100} x ${i} = ${result}`);
+            expect(result).toBe(expected);
+            i--;
+        }
+
+        expect(table).toMatchInlineSnapshot(`
+Array [
+  "100 x 10 = 1000",
+  "100 x 9 = 900",
+  "100 x 8 = 800",
+  "100 x 7 = 700",
+  "100 x 6 = 600",
+  "100 x 5 = 500",
+  "100 x 4 = 400",
+  "100 x 3 = 300",
+  "100 x 2 = 200",
+  "100 x 1 = 100",
+]
+`);
+    })
 });

--- a/tests/utils/normalize.spec.ts
+++ b/tests/utils/normalize.spec.ts
@@ -1,19 +1,34 @@
-import Normalize from '../../lib/utils/normalize-number.util';
+import Float from '../../lib/utils/normalize-number.util';
 
 describe('normalize', () => {
     it('should return 0 if provide an invalid value', () => {
         const invalid = {};
-        const result = Normalize(invalid as any);
+        const result = Float(invalid as any);
         expect(result).toBe(0);
     });
 
     it('should transform string in number if is not isNaN', () => {
-        const result = Normalize('100' as any);
+        const result = Float('100' as any);
         expect(result).toBe(100);
     });
 
-    it('should transform number in 5 decimals', () => {
-        const result = Normalize(33.33333333333 as any);
-        expect(result).toBe(33.33333);
+    it('should return the same decimals', () => {
+        const result = Float(33.33333333333);
+        expect(result).toBe(33.33333333333);
     });
+
+    it('should return 0', () => {
+        const result = Float('abc123' as any);
+        expect(result).toBe(0);
+    })
+
+    it('should return 0.33', () => {
+        const result = Float('0.33asd' as any);
+        expect(result).toBe(0.33);
+    })
+
+    it('should return 2.33', () => {
+        const result = Float('2.33asd' as any);
+        expect(result).toBe(2.33);
+    })
 });

--- a/tests/utils/subtract-number-util.spec.ts
+++ b/tests/utils/subtract-number-util.spec.ts
@@ -26,7 +26,7 @@ describe('subtract-number', () => {
         expect(result).toBe(0);
     });
 
-    it('should return value b if value a is invalid, a(0) - 10 = -10', () => {
+    it('should return value b if value a is invalid, a(0) - 10 = (-10)', () => {
         const result = Subtract('a' as unknown as number, '10' as unknown as number);
         expect(result).toBe(-10);
     });
@@ -41,7 +41,7 @@ describe('subtract-number', () => {
         expect(result).toBe(55);
     });
 
-    it('should return a(0) - 10 = 10', () => {
+    it('should return a(0) - 10 = (-10)', () => {
         const result = Subtract('a' as unknown as number, 10);
         expect(result).toBe(-10);
     });
@@ -55,4 +55,47 @@ describe('subtract-number', () => {
         const result = Subtract(10, '12' as unknown as number);
         expect(result).toBe(-2);
     });
+
+    it('should return 10a - 2 = 8', () => {
+        const result = Subtract('10a' as any, 2);
+        expect(result).toBe(8);
+    });
+
+    it('should return 20 - 2a = 18', () => {
+        const result = Subtract(20, '2a' as any);
+        expect(result).toBe(18);
+    });
+
+    it('should return 15a - 3a = 12', () => {
+        const result = Subtract('15a' as any, '3a' as any);
+        expect(result).toBe(12);
+    });
+
+    it('should implement calc with success', () => {
+        expect.assertions(11);
+        const table: string[] = [];
+        let i = 10;
+        while(i >= 1){
+            const result = Subtract(100, i, 9);
+            const expected = Number(String(100 - i).slice(0, 12));
+            table.push(`${100} - ${i} = ${result}`);
+            expect(result).toBe(expected);
+            i--;
+        }
+
+        expect(table).toMatchInlineSnapshot(`
+Array [
+  "100 - 10 = 90",
+  "100 - 9 = 91",
+  "100 - 8 = 92",
+  "100 - 7 = 93",
+  "100 - 6 = 94",
+  "100 - 5 = 95",
+  "100 - 4 = 96",
+  "100 - 3 = 97",
+  "100 - 2 = 98",
+  "100 - 1 = 99",
+]
+`);
+    })
 });

--- a/tests/utils/sum-number-util.spec.ts
+++ b/tests/utils/sum-number-util.spec.ts
@@ -65,4 +65,47 @@ describe('sum-number', () => {
         const result = Sum(42, '10' as unknown as number);
         expect(result).toBe(52);
     });
+
+    it('should return 10a + 2 = 12', () => {
+        const result = Sum('10a' as any, 2);
+        expect(result).toBe(12);
+    });
+
+    it('should return 20 + 2a = 22', () => {
+        const result = Sum(20, '2a' as any);
+        expect(result).toBe(22);
+    });
+
+    it('should return 15a + 3a = 18', () => {
+        const result = Sum('15a' as any, '3a' as any);
+        expect(result).toBe(18);
+    });
+
+    it('should implement calc with success', () => {
+        expect.assertions(11);
+        const table: string[] = [];
+        let i = 10;
+        while(i >= 1){
+            const result = Sum(100, i, 9);
+            const expected = Number(String(100 + i).slice(0, 12));
+            table.push(`${100} + ${i} = ${result}`);
+            expect(result).toBe(expected);
+            i--;
+        }
+
+        expect(table).toMatchInlineSnapshot(`
+Array [
+  "100 + 10 = 110",
+  "100 + 9 = 109",
+  "100 + 8 = 108",
+  "100 + 7 = 107",
+  "100 + 6 = 106",
+  "100 + 5 = 105",
+  "100 + 4 = 104",
+  "100 + 3 = 103",
+  "100 + 2 = 102",
+  "100 + 1 = 101",
+]
+`);
+    })
 });

--- a/tests/utils/to-decimal.spec.ts
+++ b/tests/utils/to-decimal.spec.ts
@@ -7,9 +7,9 @@ describe('to-decimal', () => {
         expect(result).toBe(value);
     });
 
-    it('should divide by 10', () => {
+    it('should divide by 100', () => {
         const value = 70;
         const result = ToDecimal(value);
-        expect(result).toBe(7);
+        expect(result).toBe(0.7);
     });
 });

--- a/tests/utils/to-long.spec.ts
+++ b/tests/utils/to-long.spec.ts
@@ -7,9 +7,9 @@ describe('to-long', () => {
         expect(result).toBe(value);
     });
 
-    it('should multiply by 10', () => {
+    it('should multiply by 100', () => {
         const value = 7;
         const result = ToLong(value);
-        expect(result).toBe(70);
+        expect(result).toBe(700);
     });
 });

--- a/tests/utils/to-precision-util.spec.ts
+++ b/tests/utils/to-precision-util.spec.ts
@@ -1,0 +1,33 @@
+import ToPrecision from '../../lib/utils/to-precision.util';
+
+describe('to-precision.util', () => {
+    it('should return numbers with 3 numbers fraction', () => {
+        const result = ToPrecision(3.1234567, 3);
+        expect(result).toBe(3.123);
+    });
+
+    it('should return numbers with 3 numbers fraction', () => {
+        const result = ToPrecision('3.1234567' as any, 3);
+        expect(result).toBe(3.123);
+    });
+
+    it('should return numbers with 2 numbers fraction', () => {
+        const result = ToPrecision(3.12, 5);
+        expect(result).toBe(3.12);
+    });
+
+    it('should return numbers with 3 numbers fraction', () => {
+        const result = ToPrecision('3.123' as any, 10);
+        expect(result).toBe(3.123);
+    });
+
+    it('should return numbers with 4 numbers fraction', () => {
+        const result = ToPrecision(3.123456, 4);
+        expect(result).toBe(3.1234);
+    });
+
+    it('should return numbers with 5 numbers fraction', () => {
+        const result = ToPrecision('3.1234567' as any, 5);
+        expect(result).toBe(3.12346);
+    });
+});

--- a/tests/utils/utils.spec.ts
+++ b/tests/utils/utils.spec.ts
@@ -106,6 +106,58 @@ describe('utils', () => {
             const result = Utils.number('70' as any).sum('7' as any);
             expect(result).toBe(77);
         });
+
+
+
+        it('should multiply 70 x 7 = 490 as number', () => {  
+            const result = Utils.number(70).multiplyBy(7, { fractionDigits: 3 });
+            expect(result).toBe(490);
+        });
+
+        it('should multiply 70 x 7 = 490 as string', () => {  
+            const result = Utils.number('70' as any).multiplyBy('7' as any, { fractionDigits: 3 });
+            expect(result).toBe(490);
+        });
+
+        it('should divide 70 / 7 = 10 as number', () => {  
+            const result = Utils.number(70).divideBy(7);
+            expect(result).toBe(10);
+        });
+
+        it('should divide 0.02 / 0.03 = 10 as number', () => {  
+            const result = Utils.number(0.02).divideBy(0.03, { fractionDigits: 2 });
+            expect(result).toBe(0.66);
+        });
+
+        it('should divide 0,02 / 0.03 = 10 as string', () => {  
+            const result = Utils.number('0.02' as any).divideBy('0.03' as any, { fractionDigits: 3 });
+            expect(result).toBe(0.666);
+        });
+
+        it('should divide 0,02 / 0.03 = 10 as string', () => {  
+            const result = Utils.number('0.02' as any).divideBy('0.03' as any);
+            expect(result).toBe(0.66666);
+        });
+
+        it('should subtract 70 - 7 = 63 as number', () => {  
+            const result = Utils.number(70).subtract(7, { fractionDigits: 3 });
+            expect(result).toBe(63);
+        });
+
+        it('should divide 70 - 7 = 63 as string', () => {  
+            const result = Utils.number('70' as any).subtract('7' as any, { fractionDigits: 3 });
+            expect(result).toBe(63);
+        });
+
+        it('should sum 70 + 7 = 77 as number', () => {  
+            const result = Utils.number(70).sum(7, { fractionDigits: 3 });
+            expect(result).toBe(77);
+        });
+
+        it('should sum 70 + 7 = 77 as string', () => {  
+            const result = Utils.number('70' as any).sum('7' as any, { fractionDigits: 3 });
+            expect(result).toBe(77);
+        });
     });
 
     describe('date', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,10 +2640,10 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^4.0.7:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-4.1.1.tgz#ec29817863e5d82d22bca82f9dc4325be2f1e72b"
-  integrity sha512-Z4Y81w8atcvaJuJuBB88VpADRH66okZAuEm+Jtaufa+s7rZmIz+Hik2G53kGaNytE7lsfXyWktTmfVz0H9xuDg==
+rimraf@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-4.1.2.tgz#20dfbc98083bdfaa28b01183162885ef213dbf7c"
+  integrity sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
### [1.17.1] - 2022-01-27

### Fix

- utils.numer: fix precision on calculation and infinity case

```ts

// Example using fractionDigits
// Default fractionDigits is 5

util.number(0.02).divideBy(0.04, { fractionDigits: 4 });

> 0.7777

```

```ts

// Example Infinity case now returns 0
// 0 / 1 = Infinity

util.number(0).divideBy(1);

> 0

```