### PR TITLE
Docs/update change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,45 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ---
+### [1.17.4] - 2022-03-15
 
+### Changed
+
+- changed: move event manager to instance of aggregate #50
+The user will still have the option of using the global event handler using `DomainEvents` class, however when adding an event using an instance of an aggregate, the event can only handle from the instance of the aggregate
+
+```ts
+
+// add event to instance of aggregate - OK
+user.addEvent(event);
+
+// dispatch from aggregate instance - OK
+user.dispatchEvent('EventName', handler);
+
+/** 
+ * if you try dispatch the event globally It will not works, because the events was added to aggregate * instance specifically
+ * The Event does not exists globally.
+*/
+DomainEvents.dispatch({ eventName: 'EventName', id: user.id }); 
+
+// to dispatch global
+// add the event globally
+DomainEvents.addEvent({ /* ... */ });
+
+// so dispatch it globally. Works!
+DomainEvents.dispatch({ /* ... */});
+
+```
+
+---
+
+### [1.17.3] - 2022-03-12
+
+### Update
+
+- update build
+
+---
 ### [1.17.2] - 2022-03-12
 
 ### Added

--- a/lib/core/events.ts
+++ b/lib/core/events.ts
@@ -2,7 +2,9 @@ import { EventHandler, IAggregate, IDispatchOptions, IDomainEvent, IEvent, IIter
 import Iterator from "./iterator";
 
 /**
- * @description Domain Events manager.
+ * @description Domain Events manager for global events.
+ * @global events for aggregates.
+ * @ignore events added in instance of aggregates directly.
  */
  export abstract class DomainEvents {
 	public static events: IIterator<IDomainEvent<IAggregate<any>>> = Iterator.create();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -292,3 +292,9 @@ export const ONE_MONTH = ONE_DAY * 30;
 export const ONE_YEAR = ONE_DAY * 365;
 
 export type CalcOpt = { fractionDigits: number };
+
+export interface EventMetrics {
+	current: number;
+	total: number;
+	dispatch: number;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.17.3",
+	"version": "1.17.4",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.17.2",
+	"version": "1.17.3",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",


### PR DESCRIPTION
### [1.17.4] - 2022-03-15

### Changed

- changed: move event manager to instance of aggregate #50
The user will still have the option of using the global event handler using `DomainEvents` class, however when adding an event using an instance of an aggregate, the event can only handle from the instance of the aggregate

```ts

// add event to instance of aggregate - OK
user.addEvent(event);

// dispatch from aggregate instance - OK
user.dispatchEvent('EventName', handler);

/** 
 * if you try dispatch the event globally It will not works, because the events was added to aggregate * instance specifically
 * The Event does not exists globally.
*/
DomainEvents.dispatch({ eventName: 'EventName', id: user.id }); 

// to dispatch global
// add the event globally
DomainEvents.addEvent({ /* ... */ });

// so dispatch it globally. Works!
DomainEvents.dispatch({ /* ... */});

```