### PR TITLE
Docs/update change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ---
-### [1.17.4] - 2022-03-15
+### [1.18.0] - 2022-03-15
 
 ### Changed
 
-- changed: move event manager to instance of aggregate #50
+- changed: move event manager to instance of aggregate #50 by [Paulo Santana](https://github.com/hikinine)
+
 The user will still have the option of using the global event handler using `DomainEvents` class, however when adding an event using an instance of an aggregate, the event can only handle from the instance of the aggregate
 
 ```ts
@@ -32,6 +33,20 @@ DomainEvents.addEvent({ /* ... */ });
 
 // so dispatch it globally. Works!
 DomainEvents.dispatch({ /* ... */});
+
+```
+
+- changed: Result properties to private using # to do not serialize private keys
+- changed: Types for create method: Entity, Aggregate and ValueObject
+- changed: Clone method in Entity and Aggregate instance. Now It accepts optional props.
+
+```ts
+
+// create a copy of user instance and also copy domain events from original aggregate user.
+const userCopy = user.clone({ copyEvents: true });
+
+// create a copy and apply a new name value
+const userCopy = user.clone({ name });
 
 ```
 

--- a/lib/core/create-many-domain-instance.ts
+++ b/lib/core/create-many-domain-instance.ts
@@ -24,8 +24,8 @@ export const createManyDomainInstances = (data: ICreateManyDomain): ICreateManyR
 				continue;
 			};
 
-			const result = data[index].class.create(data[index].props);
-			results.push(result);
+			const payload = data[index].class.create(data[index].props);
+			results.push(payload);
 		}
 	}
 

--- a/lib/core/entity.ts
+++ b/lib/core/entity.ts
@@ -7,10 +7,10 @@ import Result from "./result";
 /**
  * @description Entity identified by an id
  */
- export class Entity<Props extends EntityProps> extends GettersAndSetters<Props> implements IEntity<Props> {
-	 protected _id: UID<string>;
-	 protected autoMapper: AutoMapper<Props>;
-	constructor(props: Props, config?: ISettings) { 
+export class Entity<Props extends EntityProps> extends GettersAndSetters<Props> implements IEntity<Props> {
+	protected _id: UID<string>;
+	protected autoMapper: AutoMapper<Props>;
+	constructor(props: Props, config?: ISettings) {
 		super(Object.assign({}, { createdAt: new Date(), updatedAt: new Date() }, { ...props }), 'Entity', config);
 		const isID = this.validator.isID(props?.['id']);
 		const isStringOrNumber = this.validator.isString(props?.['id']) || this.validator.isNumber(props?.['id']);
@@ -25,15 +25,15 @@ import Result from "./result";
 	 * @returns true if props is equal and false if not.
 	*/
 	isEqual(other: Entity<Props>): boolean {
-		const currentProps = Object.assign({}, {}, { ...this.props});
-		const providedProps = Object.assign({}, {}, { ...other.props});
+		const currentProps = Object.assign({}, {}, { ...this.props });
+		const providedProps = Object.assign({}, {}, { ...other.props });
 		delete currentProps?.['createdAt'];
 		delete currentProps?.['updatedAt'];
 		delete providedProps?.['createdAt'];
 		delete providedProps?.['updatedAt'];
 		const equalId = this.id.equal(other.id);
 		const serializedA = JSON.stringify(currentProps);
-		const serializedB = JSON.stringify(providedProps);		
+		const serializedB = JSON.stringify(providedProps);
 		const equalSerialized = serializedA === serializedB;
 		return equalId && equalSerialized;
 	}
@@ -80,15 +80,16 @@ import Result from "./result";
 	/**
 	 * @description Get a new instanced based on current Entity.
 	 * @summary if not provide an id a new one will be generated.
+	 * @param props as optional Entity Props.
 	 * @returns new Entity instance.
 	 */
-	clone(): Entity<Props> {
+	clone(props?: Partial<Props>): this {
+		const _props = props ? { ...this.props, ...props } : this.props;
 		const instance = Reflect.getPrototypeOf(this);
-		const args = [this.props, this.config];
+		const args = [_props, this.config];
 		const entity = Reflect.construct(instance!.constructor, args);
 		return entity
 	}
-
 
 	/**
 	 * @description Method to validate props. This method is used to validate props on create a instance.
@@ -99,6 +100,7 @@ import Result from "./result";
 		return !this.validator.isUndefined(props) && !this.validator.isNull(props);
 	};
 
+	public static create(props: any): IResult<Entity<any>>;
 	/**
 	 * 
 	 * @param props params as Props
@@ -106,8 +108,8 @@ import Result from "./result";
 	 * @returns instance of result with a new Entity on state if success.
 	 * @summary result state will be `null` case failure.
 	 */
-	public static create(props: any): IResult<Entity<any>, any, any> {
-		if(!this.isValidProps(props)) return Result.fail('Invalid props to create an instance of ' + this.name);
+	public static create(props: {}): Result<Entity<{}>> {
+		if (!this.isValidProps(props)) return Result.fail('Invalid props to create an instance of ' + this.name);
 		return Result.Ok(new this(props));
 	};
 }

--- a/lib/core/result.ts
+++ b/lib/core/result.ts
@@ -10,18 +10,18 @@ import Iterator from "./iterator";
  */
 export class Result<T = void, D = string, M = {}> implements IResult<T, D, M> {
 
-	private readonly _isSuccess: boolean;
-	private readonly _isFailure: boolean;
-	private readonly _data: T | null;
-	private readonly _error: D | null;
-	private readonly _metaData: M;
+	#isOk: Readonly<boolean>;
+	#isFail: Readonly<boolean>;
+	#data: Readonly<T | null>;
+	#error: Readonly<D | null>;
+	#metaData: Readonly<M>;
 
 	private constructor(isSuccess: boolean, data?: T, error?: D, metaData?: M) {
-		this._isSuccess = isSuccess;
-		this._isFailure = !isSuccess;
-		this._data = data ?? null;
-		this._error = error ?? null;
-		this._metaData = metaData ?? {} as M;
+		this.#isOk = isSuccess;
+		this.#isFail = !isSuccess;
+		this.#data = data ?? null;
+		this.#error = error ?? null;
+		this.#metaData = metaData ?? {} as M;
 	}
 
 	/**
@@ -103,7 +103,7 @@ export class Result<T = void, D = string, M = {}> implements IResult<T, D, M> {
 		if (iterator.isEmpty()) return Result.fail('No results provided on combine param' as B) as IResult<A, B, M>;
 		while (iterator.hasNext()) {
 			const currentResult = iterator.next();
-			if (currentResult.isFail()) return currentResult as IResult<A, B, M>;;
+			if (currentResult.isFail()) return currentResult as IResult<A, B, M>;
 		}
 		return iterator.first() as IResult<A, B, M>;
 	}
@@ -150,14 +150,14 @@ export class Result<T = void, D = string, M = {}> implements IResult<T, D, M> {
 	 * @returns `data` T or `null` case result is failure.
 	 */
 	value(): T {
-		return this._data as T;
+		return this.#data as T;
 	}
 	/**
 	 * @description Get the instance error.
 	 * @returns `error` D or `null` case result is success.
 	 */
 	error(): D {
-		return this._error as D;
+		return this.#error as D;
 	}
 
 	/**
@@ -165,7 +165,7 @@ export class Result<T = void, D = string, M = {}> implements IResult<T, D, M> {
 	 * @returns `true` case result instance failure or `false` case is success one.
 	 */
 	isFail(): boolean {
-		return this._isFailure;
+		return this.#isFail;
 	}
 
 	/**
@@ -173,7 +173,7 @@ export class Result<T = void, D = string, M = {}> implements IResult<T, D, M> {
 	 * @returns `true` case result instance success or `false` case is failure one.
 	 */
 	isOk(): boolean {
-		return this._isSuccess;
+		return this.#isOk;
 	}
 
 	/**
@@ -181,7 +181,7 @@ export class Result<T = void, D = string, M = {}> implements IResult<T, D, M> {
 	 * @returns `metadata` M or `{}` result in case of empty object has no metadata value.
 	 */
 	metaData(): M {
-		const metaData = this._metaData;
+		const metaData = this.#metaData;
 		return Object.freeze(metaData);
 	}
 
@@ -199,11 +199,11 @@ export class Result<T = void, D = string, M = {}> implements IResult<T, D, M> {
 	 */
 	toObject(): IResultObject<T, D, M> {
 		const metaData = {
-			isOk: this._isSuccess,
-			isFail: this._isFailure,
-			data: this._data as T | null,
-			error: this._error as D | null,
-			metaData: this._metaData as M
+			isOk: this.#isOk,
+			isFail: this.#isFail,
+			data: this.#data as T | null,
+			error: this.#error as D | null,
+			metaData: this.#metaData as M
 		}
 
 		return Object.freeze(metaData);

--- a/lib/core/value-object.ts
+++ b/lib/core/value-object.ts
@@ -80,13 +80,14 @@ export class ValueObject<Props> extends GettersAndSetters<Props> implements IVal
 		return !this.validator.isUndefined(props) && !this.validator.isNull(props);
 	};
 
+	public static create(props: any): IResult<ValueObject<any>>;
 	/**
 	 * 
 	 * @param props params as Props
 	 * @returns instance of result with a new Value Object on state if success.
 	 * @summary result state will be `null` case failure.
 	 */
-	public static create(props: any): IResult<ValueObject<any>, any, any> {
+	public static create(props: {}): Result<ValueObject<{}>> {
 		if (!this.isValidProps(props)) return Result.fail('Invalid props to create an instance of ' + this.name);
 		return Result.Ok(new this(props));
 	};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.17.4",
+	"version": "1.18.0",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/tests/core/result.spec.ts
+++ b/tests/core/result.spec.ts
@@ -159,4 +159,16 @@ describe('result', () => {
 		});
 
 	});
+
+	describe('result serialized', () => {
+		it('should Ok do not have none public key', () => {
+			const result = Ok();
+			expect(JSON.stringify(result)).toMatchInlineSnapshot(`"{}"`);
+		});
+
+		it('should Fail do not have none public key', () => {
+			const result = Fail();
+			expect(JSON.stringify(result)).toMatchInlineSnapshot(`"{}"`);
+		});
+	});
 });


### PR DESCRIPTION
#50 

- changed: Result properties to private using # to do not serialize private keys
- changed: Types for create method: Entity, Aggregate and ValueObject
- changed: Clone method in Entity and Aggregate instance. Now It accepts optional props.

```ts

// create a copy of user instance and also copy domain events from original aggregate user.
const userCopy = user.clone({ copyEvents: true });

// create a copy and apply a new name value
const userCopy = user.clone({ name });

```