### PR TITLE
feat: added adapter custom err type (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### [1.18.3] - 2022-07-30
+
+### Fixed
+
+- fixed: ensure custom payload error to adapter
+
+---
+
 ### [1.18.2] - 2022-07-09
 
 ### Fixed

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -223,8 +223,8 @@ export interface IEvent<G> {
 
 export type IReplaceOptions = 'REPLACE_DUPLICATED' | 'UPDATE' | 'KEEP';
 
-export interface IAdapter<F, T> {
-	build(target: F): IResult<T>;
+export interface IAdapter<F, T, E = any, M = any> {
+	build(target: F): IResult<T, E, M>;
 }
 
 export interface IEntity<Props> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.18.2",
+	"version": "1.18.3",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",


### PR DESCRIPTION
https://github.com/4lessandrodev/types-ddd/issues/282

### Example implementation

```ts

	type In = { a: number };
	type Out = { b: string };
	type Err = { err: string; stack?: string };

	class CustomAdapter implements IAdapter<In, Out, Err>{
		build(target: In): IResult<Out, Err> {
			if (typeof target.a !== 'number') return Fail({ err: 'target.a is not a number' });
			return Ok({ b: target.a.toString() });
		}
	}

	const adapter = new CustomAdapter();

```

### Example payload

```ts

	const result = adapter.build({ a: null as any });
	expect(result.isFail()).toBeTruthy();
	expect(result.error()).toEqual({ err: 'target.a is not a number' });

```