### PR TITLE
Fix/compare null undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### [1.18.4] - 2022-07-23
+
+### Fixed
+
+- fixed: ensure compare null or undefined using `isEqual` method on value-object, entity and aggregate instance.
+- fixed: ensure create props copy on clone domain entities.
+- added: create a shortcut to `isEqual` method on id instance to compare values.
+- changed: mark history (`snapshot`) method as deprecated. Will be removed on next version to improve performance.
+- change: update deps
+
+---
+
 ### [1.18.3] - 2022-07-30
 
 ### Fixed
@@ -14,7 +26,6 @@ All notable changes to this project will be documented in this file.
 - fixed: ensure custom payload error to adapter
 
 ---
-
 ### [1.18.2] - 2022-07-09
 
 ### Fixed

--- a/lib/core/aggregate.ts
+++ b/lib/core/aggregate.ts
@@ -52,7 +52,7 @@ export class Aggregate<Props extends EntityProps> extends Entity<Props> implemen
 	 * @returns new Aggregate instance.
 	 */
 	clone(props?: Partial<Props> & { copyEvents?: boolean }): this {
-		const _props = props ? { ...this.props, ...props } : this.props;
+		const _props = props ? { ...this.props, ...props } : { ...this.props };
 		const _events = (props && !!props.copyEvents) ? this._domainEvents : [];
 		const instance = Reflect.getPrototypeOf(this);
 		const args = [_props, this.config, _events];

--- a/lib/core/entity.ts
+++ b/lib/core/entity.ts
@@ -20,18 +20,18 @@ export class Entity<Props extends EntityProps> extends GettersAndSetters<Props> 
 
 	/** 
 	 * @description Check if entity instance props is equal another provided instance props.
-	 * @param createdAt is not considered on comparation
-	 * @param updatedAt is not considered on comparation
+	 * @param createdAt is not considered on compare
+	 * @param updatedAt is not considered on compare
 	 * @returns true if props is equal and false if not.
 	*/
-	isEqual(other: Entity<Props>): boolean {
-		const currentProps = Object.assign({}, {}, { ...this.props });
-		const providedProps = Object.assign({}, {}, { ...other.props });
+	isEqual(other: this): boolean {
+		const currentProps = Object.assign({}, {}, { ...this?.props });
+		const providedProps = Object.assign({}, {}, { ...other?.props });
 		delete currentProps?.['createdAt'];
 		delete currentProps?.['updatedAt'];
 		delete providedProps?.['createdAt'];
 		delete providedProps?.['updatedAt'];
-		const equalId = this.id.equal(other.id);
+		const equalId = this.id.equal(other?.id);
 		const serializedA = JSON.stringify(currentProps);
 		const serializedB = JSON.stringify(providedProps);
 		const equalSerialized = serializedA === serializedB;
@@ -84,7 +84,7 @@ export class Entity<Props extends EntityProps> extends GettersAndSetters<Props> 
 	 * @returns new Entity instance.
 	 */
 	clone(props?: Partial<Props>): this {
-		const _props = props ? { ...this.props, ...props } : this.props;
+		const _props = props ? { ...this.props, ...props } : { ...this.props };
 		const instance = Reflect.getPrototypeOf(this);
 		const args = [_props, this.config];
 		const entity = Reflect.construct(instance!.constructor, args);

--- a/lib/core/getters-and-setters.ts
+++ b/lib/core/getters-and-setters.ts
@@ -10,6 +10,9 @@ import ID from "./id";
  * @description defines getter and setter to all domain instances.
  */
 export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
+	/**
+	 * @deprecated this method will be removed on next version
+	 */
 	private readonly _MetaHistory: IHistory<Props>;
 	protected validator: Validator = validator;
 	protected static validator: Validator = validator;
@@ -63,6 +66,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 	}
 
 	/**
+	 * @deprecated this method will be removed on next version
 	 * @description Create a snapshot as update action.
 	 * @returns void.
 	 * @see change
@@ -310,6 +314,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 	/**
 	 * @description Manage props state as history.
 	 * @returns IPublicHistory<Props>
+	 * @deprecated this method will be removed on next version
 	 */
 	history(): IPublicHistory<Props> {
 		return {
@@ -317,6 +322,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 			 * @description Get previous props state and apply to instance.
 			 * @param token a 16bytes value to identify the target state on history.
 			 * @returns previous state found.
+			 * @deprecated this method will be removed on next version
 			 */
 			back: (token?: UID<string>): IHistoryProps<Props> => {
 				const prevState = this._MetaHistory.back(token);
@@ -328,6 +334,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 			 * @description Get next props state and apply to instance.
 			 * @param token a 16bytes value to identify the target state on history.
 			 * @returns next state found.
+			 * @deprecated this method will be removed on next version
 			 */
 			forward: (token?: UID<string>): IHistoryProps<Props> => {
 				const nextState = this._MetaHistory.forward(token);
@@ -338,7 +345,8 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 			/**
 			 * @description Create a new snapshot from current state.
 			 * @param token a 16bytes key to identify the state on history.
-			 * @returns 
+			 * @returns
+			 * @deprecated this method will be removed on next version
 			 */
 			snapshot: (token?: UID<string>): IHistoryProps<Props> => {
 				return this._MetaHistory.snapshot({
@@ -352,6 +360,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 			/**
 			 * @description Get all props on state as history.
 			 * @returns a list of props on state.
+			 * @deprecated this method will be removed on next version
 			 */
 			list: (): IHistoryProps<Props>[] => {
 				return this._MetaHistory.list()
@@ -360,6 +369,7 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 			/**
 			 * @description Get total of props on state as history.
 			 * @returns total of props on state.
+			 * @deprecated this method will be removed on next version
 			 */
 			count: (): number => {
 				return this._MetaHistory.count()

--- a/lib/core/history.ts
+++ b/lib/core/history.ts
@@ -3,6 +3,7 @@ import ID from "./id";
 import Iterator from "./iterator";
 
 /**
+ * @deprecated this method will be removed on next version
  * @description Manage state props as history.
  */
  export class History<Props> implements IHistory<Props> {

--- a/lib/core/id.ts
+++ b/lib/core/id.ts
@@ -97,7 +97,16 @@ export class ID<T = string> implements UID<T> {
 	 * @returns `true` if provided id value and instance value has the same value and `false` if not.
 	 */
 	equal(id: UID<any>): boolean {
-		return (typeof this._value === typeof id.value()) && (this._value as any === id.value());
+		return (typeof this._value === typeof id?.value()) && (this._value as any === id?.value());
+	}
+
+	/**
+	 * @description Compare value from instance and provided id.
+	 * @param id instance of ID
+	 * @returns `true` if provided id value and instance value has the same value and `false` if not.
+	 */
+	isEqual(id: UID<any>): boolean {
+		return this.equal(id);
 	}
 
 	/**

--- a/lib/core/value-object.ts
+++ b/lib/core/value-object.ts
@@ -15,13 +15,13 @@ export class ValueObject<Props> extends GettersAndSetters<Props> implements IVal
 
 	/** 
 	 * @description Check if value object instance props is equal another provided instance props.
-	 * @param createdAt is not considered on comparation
-	 * @param updatedAt is not considered on comparation
+	 * @param createdAt is not considered on compare
+	 * @param updatedAt is not considered on compare
 	 * @returns true if props is equal and false if not.
 	*/
-	isEqual(other: ValueObject<Props>): boolean {
-		const currentProps = Object.assign({}, {}, { ...this.props});
-		const providedProps = Object.assign({}, {}, { ...other.props});
+	isEqual(other: this): boolean {
+		const currentProps = Object.assign({}, {}, { ...this?.props});
+		const providedProps = Object.assign({}, {}, { ...other?.props});
 		delete currentProps?.['createdAt'];
 		delete currentProps?.['updatedAt'];
 		delete providedProps?.['createdAt'];
@@ -33,9 +33,10 @@ export class ValueObject<Props> extends GettersAndSetters<Props> implements IVal
 	 * @description Get an instance copy.
 	 * @returns a new instance of value object.
 	 */
-	clone(): ValueObject<Props> {
+	clone(props?: Partial<Props>): ValueObject<Props> {
+		const _props = props ? { ...this.props, ...props } : { ...this.props };
 		const instance = Reflect.getPrototypeOf(this);
-		const args = [this.props, this.config];
+		const args = [_props, this.config];
 		const obj = Reflect.construct(instance!.constructor, args);
 		return obj;
 	}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,7 @@ export interface UID<T = string> {
 	createdAt(): Date;
 	isShort(): boolean;
 	equal(id: UID<string>): boolean;
+	isEqual(id: UID<string>): boolean;
 	deepEqual(id: UID<string>): boolean;
 	cloneAsNew(): UID<string>;
 	clone(): UID<T>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.18.3",
+	"version": "1.18.4",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/tests/core/entity.spec.ts
+++ b/tests/core/entity.spec.ts
@@ -1,4 +1,4 @@
-import {  Entity, Id, Ok, Result, ValueObject } from "../../lib/core";
+import { Entity, Id, Ok, Result, ValueObject } from "../../lib/core";
 import { IResult, UID } from "../../lib/types";
 
 describe("entity", () => {
@@ -6,7 +6,7 @@ describe("entity", () => {
 	describe("simple entity", () => {
 
 		interface Props { id?: string, foo: string };
-		
+
 		class EntitySample extends Entity<Props> {
 			private constructor(props: Props) {
 				super(props);
@@ -25,7 +25,7 @@ describe("entity", () => {
 			const ent = EntitySample.create({ foo: 'bar' });
 
 			ent.value().change('foo', 'changed');
-			expect(ent.isOk()).toBeTruthy();	
+			expect(ent.isOk()).toBeTruthy();
 		});
 	});
 
@@ -99,7 +99,7 @@ describe("entity", () => {
 
 	describe("should accept validation without error", () => {
 		interface Props { id?: string, foo: string };
-		
+
 		class EntitySample extends Entity<Props> {
 			private constructor(props: Props) {
 				super(props);
@@ -166,43 +166,43 @@ describe("entity", () => {
 
 		it("should to be equal", () => {
 
-			const props = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
+			const props = { key: 200, values: [{ name: 'abc' }, { name: 'def' }] } satisfies Props;
 			const id = Id();
 
-			const a = EntityExample.create({...props, id }).value();
-			const b = EntityExample.create({...props, id}).value();
-			
+			const a = EntityExample.create({ ...props, id }).value();
+			const b = EntityExample.create({ ...props, id }).value();
+
 			expect(a.isEqual(b)).toBeTruthy();
 		});
 
 		it("should to be equal", () => {
 
 			const id = Id();
-			const props = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
+			const props = { key: 200, values: [{ name: 'abc' }, { name: 'def' }] } satisfies Props;
 
-			const a = EntityExample.create({...props, id}).value();
+			const a = EntityExample.create({ ...props, id }).value();
 			const b = a.clone();
-			
+
 			expect(a.isEqual(b)).toBeTruthy();
 		});
 
 		it("should not to be equal if change state", () => {
 
 			const id = Id();
-			const props = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
+			const props = { key: 200, values: [{ name: 'abc' }, { name: 'def' }] } satisfies Props;
 
-			const a = EntityExample.create({...props, id}).value();
+			const a = EntityExample.create({ ...props, id }).value();
 			const b = a.clone();
 			b.set('key').to(201);
-			
+
 			expect(a.isEqual(b)).toBeFalsy();
 		});
 
 		it("should not to be equal if state is different", () => {
 
 			const id = Id();
-			const propsA = { id, key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
-			const propsB = { id, key: 200, values:[ {name: 'abc'},{name: 'dif'}] } satisfies Props;
+			const propsA = { id, key: 200, values: [{ name: 'abc' }, { name: 'def' }] } satisfies Props;
+			const propsB = { id, key: 200, values: [{ name: 'abc' }, { name: 'dif' }] } satisfies Props;
 
 			const a = EntityExample.create(propsA).value();
 			const b = EntityExample.create(propsB).value();
@@ -212,25 +212,33 @@ describe("entity", () => {
 
 		it("should not to be equal if id is different", () => {
 
-			const propsA = { key: 200, values:[ {name: 'abc'},{name: 'def'}] } satisfies Props;
-			const propsB = { key: 200, values:[ {name: 'abc'},{name: 'dif'}] } satisfies Props;
+			const propsA = { key: 200, values: [{ name: 'abc' }, { name: 'def' }] } satisfies Props;
+			const propsB = { key: 200, values: [{ name: 'abc' }, { name: 'dif' }] } satisfies Props;
 
 			const a = EntityExample.create(propsA).value();
 			const b = EntityExample.create(propsB).value();
 
 			expect(a.isEqual(b)).toBeFalsy();
 		});
+
+		it("should compare null and undefined", () => {
+
+			const propsA = { key: 200, values: [{ name: 'abc' }, { name: 'def' }] } satisfies Props;
+			const a = EntityExample.create(propsA).value();
+			expect(a.isEqual(null as unknown as EntityExample)).toBeFalsy();
+			expect(a.isEqual(undefined as unknown as EntityExample)).toBeFalsy();
+		});
 	});
 	describe("util", () => {
 
 		interface Props { id?: string, foo: string };
-		
+
 		class ValSamp extends Entity<Props> {
 			private constructor(props: Props) {
 				super(props);
 			}
 
-			public static isValidProps(value: string): boolean {		
+			public static isValidProps(value: string): boolean {
 				return this.validator.string(value).hasLengthBetween(3, 50);
 			}
 
@@ -240,7 +248,7 @@ describe("entity", () => {
 
 			public static create(props: Props): IResult<ValSamp> {
 				const isValid = this.isValidProps(props.foo);
-				if(!isValid) return Result.fail('Erro');
+				if (!isValid) return Result.fail('Erro');
 				return Result.Ok(new ValSamp(props))
 			}
 		}

--- a/tests/core/id.spec.ts
+++ b/tests/core/id.spec.ts
@@ -54,12 +54,14 @@ describe('ID', () => {
 		it('null must not be equal', () => {
 			expect(typeof ID.create(null).value() === 'string').toBeTruthy();
 			expect(ID.create(null).equal(ID.create())).toBeFalsy();
+			expect(ID.create(null).isEqual(ID.create())).toBeFalsy();
 		});
 
 		it('must be equal', () => {
 			const a = ID.create(null);
 			const b = ID.create(null);
 			expect(a.deepEqual(b)).toBeTruthy();
+			expect(a.isEqual(b)).toBeTruthy();
 		});
 
 		it('must clone id as a new one', () => {
@@ -68,6 +70,7 @@ describe('ID', () => {
 
 			const clone = a.cloneAsNew();
 			expect(clone.equal(a)).toBeTruthy();
+			expect(clone.isEqual(a)).toBeTruthy();
 
 			expect(clone.isNew()).toBeTruthy();
 

--- a/tests/core/value-object.spec.ts
+++ b/tests/core/value-object.spec.ts
@@ -228,6 +228,26 @@ describe('value-object', () => {
 			expect(sample.value().toObject()).toEqual(result.toObject())
 		});
 
+		it('should clone a value object with custom props', () => {
+
+			interface Props { value: string; foo: string; }
+			class Sample extends ValueObject<Props>{
+				private constructor(props: Props) {
+					super(props);
+				}
+
+				public static create(props: Props): Result<Sample> {
+					return Ok(new Sample(props));
+				}
+			};
+
+			const sample = Sample.create({ value: 'Sample', foo: 'bar' });
+
+			const result = sample.value().clone({ foo: 'other' });
+
+			expect(result.toObject()).toEqual({ foo: 'other', value: 'Sample' });
+		});
+
 		it('should navigate for history', () => {
 
 			interface Props { value: string, foo: string };
@@ -344,9 +364,9 @@ describe('value-object', () => {
 		it('should disable set with success', () => {
 			const result = HumanAge.create({ value: 10, birthDay: new Date('2022-01-01T03:00:00.000Z') });
 			const age = result.value();
-			
+
 			expect(age.get('value')).toBe(10);
-			
+
 			age.set('birthDay').to(new Date());
 			age.set('value').to(55);
 
@@ -524,11 +544,11 @@ describe('value-object', () => {
 			expect(result.value().get('value')).toBe('valid_value');
 
 			result.value().set('value').to('change_value');
-			
+
 			expect(result.value().get('value')).toBe('change_value');
-	
+
 			result.value().set('value').to('invalid');
-	
+
 			expect(result.value().get('value')).toBe('change_value');
 		})
 	});
@@ -539,7 +559,7 @@ describe('value-object', () => {
 			value: string;
 		}
 		class Exam extends ValueObject<Props> {
-			private constructor(props: Props){
+			private constructor(props: Props) {
 				super(props)
 			}
 
@@ -549,22 +569,22 @@ describe('value-object', () => {
 		};
 
 		it('should to be equal another instance', () => {
-			const a = Exam.create({ value : "hello there" }).value();
-			const b = Exam.create({ value : "hello there" }).value();
+			const a = Exam.create({ value: "hello there" }).value();
+			const b = Exam.create({ value: "hello there" }).value();
 
 			expect(a.isEqual(b)).toBeTruthy();
 		});
 
 		it('should to be equal another instance', () => {
-			const a = Exam.create({ value : "hello there" }).value();
+			const a = Exam.create({ value: "hello there" }).value();
 			const b = a.clone();
 
 			expect(a.isEqual(b)).toBeTruthy();
 		});
 
 		it('should not to be equal another instance', () => {
-			const a = Exam.create({ value : "hello there 1" }).value();
-			const b = Exam.create({ value : "hello there 2" }).value();
+			const a = Exam.create({ value: "hello there 1" }).value();
+			const b = Exam.create({ value: "hello there 2" }).value();
 
 			expect(a.isEqual(b)).toBeFalsy();
 		});
@@ -576,12 +596,12 @@ describe('value-object', () => {
 			value: string;
 		}
 		class Exam extends ValueObject<Props> {
-			private constructor(props: Props){
+			private constructor(props: Props) {
 				super(props)
 			}
 
 			RemoveSpaces(fromValue?: string): string {
-				if(fromValue) return this.util.string(fromValue).removeSpaces();
+				if (fromValue) return this.util.string(fromValue).removeSpaces();
 				return this.util.string(this.props.value).removeSpaces();
 			}
 
@@ -595,18 +615,50 @@ describe('value-object', () => {
 		};
 
 		it('should remove spaces', () => {
-			const a = Exam.create({ value : " Some Value With Many Space" }).value();
+			const a = Exam.create({ value: " Some Value With Many Space" }).value();
 			expect(a.RemoveSpaces()).toBe('SomeValueWithManySpace');
 		});
 
 		it('should remove special chars', () => {
-			const a = Exam.create({ value : "#Some@Value&With%Many*Special-Chars" }).value();
+			const a = Exam.create({ value: "#Some@Value&With%Many*Special-Chars" }).value();
 			expect(a.RemoveSpecialChars()).toBe('SomeValueWithManySpecialChars');
 		});
 
 		it('should remove special chars and spaces', () => {
-			const a = Exam.create({ value : "#Some @Value &With %Many *Special-Chars" }).value();
+			const a = Exam.create({ value: "#Some @Value &With %Many *Special-Chars" }).value();
 			expect(a.RemoveSpaces(a.RemoveSpecialChars())).toBe('SomeValueWithManySpecialChars');
 		});
+	});
+
+	describe('compare', () => {
+
+		interface Props { value: string };
+		class Simple extends ValueObject<Props> {
+			constructor(props: Props) {
+				super(props)
+			}
+
+			public static create(props: Props): IResult<Simple> {
+				return Result.Ok(new Simple(props));
+			}
+		}
+
+		it('should infer type on compare', () => {
+			const a = Simple.create({ value: 'a' }).value();
+			const b = Simple.create({ value: 'b' }).value();
+			const c = Simple.create({ value: 'a' }).value();
+
+			expect(a.isEqual(b)).toBeFalsy();
+			expect(a.isEqual(c)).toBeTruthy();
+		});
+
+		it('should compare nullable or undefined', () => {
+			const a = Simple.create({ value: 'a' }).value();
+			const b = Simple.create({ value: 'b' }).value();
+
+			expect(a.isEqual(null as unknown as Simple)).toBeFalsy();
+			expect(b.isEqual(undefined as unknown as Simple)).toBeFalsy();
+		});
+
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,10 +703,15 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@*", "@types/node@^20.3.2":
+"@types/node@*":
   version "20.5.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.1.tgz#178d58ee7e4834152b0e8b4d30cbfab578b9bb30"
   integrity sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==
+
+"@types/node@^20.3.2":
+  version "20.5.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.4.tgz#4666fb40f9974d60c53c4ff554315860ba4feab8"
+  integrity sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA==
 
 "@types/prettier@^2.1.5":
   version "2.7.0"


### PR DESCRIPTION
### Fixed

- fixed: ensure compare null or undefined using `isEqual` method on value-object, entity and aggregate instance.
- fixed: ensure create props copy on clone domain entities.
- added: create a shortcut to `isEqual` method on id instance to compare values.
- changed: mark history (`snapshot`) method as deprecated. Will be removed on next version to improve performance.
- change: update deps