### PR TITLE
fix: ensure bind event handler context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### [1.20.1] - 2024-03-24
+
+### Fixed
+
+- Added context binding (this.bind(this)) to the EventHandler class constructor to ensure proper access to class properties and methods within event handlers.
+
+---
+
 ### [1.20.0] - 2024-03-17
 
 ### Changed

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -332,6 +332,7 @@ export abstract class EventHandler<T> {
         if (typeof params?.eventName !== 'string') {
             throw new Error('params.eventName is required as string');
         }
+		this.dispatch = this.dispatch.bind(this);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.20.0",
+	"version": "1.20.1",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/tests/core/events.spec.ts
+++ b/tests/core/events.spec.ts
@@ -204,5 +204,37 @@ describe('events', () => {
                 ],
             ]
         );
-    })
+    });
+
+    it('should bind this to instance', () => {
+
+        let payload: { email: string } | null = null;
+
+        interface Mailer {
+            sendEmail(arg: { email: string }): void;
+        }
+
+        class SesMailer implements Mailer {
+            sendEmail(arg: { email: string }) {
+                payload = arg;
+            }
+        }
+
+        class SignupEvent extends EventHandler<{ email: string }> {
+            constructor(
+                private readonly mailer: Mailer
+            ) {
+                super({ eventName: 'SignupEvent' });
+            }
+            async dispatch(account: { email: string }): Promise<void> {
+                this.mailer.sendEmail(account);
+            }
+        }
+
+        const data = { email: 'jane@mail.com' };
+        const event = new SignupEvent(new SesMailer());
+        event.dispatch(data);
+
+        expect(payload).toEqual(data);
+    });
 });


### PR DESCRIPTION
#126 

### [1.20.1] - 2024-03-24

### Fixed

- Added context binding (this.bind(this)) to the EventHandler class constructor to ensure proper access to class properties and methods within event handlers.