### PR TITLE
#145 Feat: AutoMapperSerializer - add types for to object method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,10 +577,13 @@ context.dispatchEvent('CONTEXT:EVENT', { name: 'Jane' });
 // Dispatching events to specific contexts
 // Dispatches the SIGNUP event to Context-X
 context.dispatchEvent('Context-X:SIGNUP'); 
+
 // Dispatches the SIGNUP event to all contexts
 context.dispatchEvent('*:SIGNUP'); 
+
 // Dispatches all events to all contexts. Not recommended
 context.dispatchEvent('*:*'); 
+
 // Dispatches all events under Context-Y
 context.dispatchEvent('Context-Y:*'); 
 

--- a/lib/core/auto-mapper.ts
+++ b/lib/core/auto-mapper.ts
@@ -1,4 +1,4 @@
-import { EntityMapperPayload, IAutoMapper, IEntity, IValueObject } from "../types";
+import { AutoMapperSerializer, EntityMapperPayload, IAutoMapper, IEntity, IValueObject } from "../types";
 import { Validator } from "../utils";
 import ID from "./id";
 
@@ -13,10 +13,10 @@ export class AutoMapper<Props> implements IAutoMapper<Props> {
 	 * @param valueObject as instance.
 	 * @returns an object or a value object value.
 	 */
-	valueObjectToObj(valueObject: IValueObject<Props>): { [key in keyof Props]: any } {
-		
+	valueObjectToObj(valueObject: IValueObject<Props>): AutoMapperSerializer<Props> {
+
 		// internal state
-		if(valueObject === null) return null as any;
+		if (valueObject === null) return null as any;
 
 		if (this.validator.isID(valueObject)) return (valueObject as any)?.value();
 
@@ -28,7 +28,7 @@ export class AutoMapper<Props> implements IAutoMapper<Props> {
 			this.validator.isObject(valueObject) ||
 			this.validator.isDate(valueObject);
 
-		if (isSimpleValue) return valueObject as { [key in keyof Props]: any };
+		if (isSimpleValue) return valueObject as AutoMapperSerializer<Props>
 
 		const isID = this.validator.isID(valueObject);
 
@@ -103,7 +103,7 @@ export class AutoMapper<Props> implements IAutoMapper<Props> {
 	 * @param entity instance.
 	 * @returns a simple object.
 	 */
-	entityToObj(entity: IEntity<Props>): { [key in keyof Props]: any } & EntityMapperPayload {
+	entityToObj(entity: IEntity<Props>): AutoMapperSerializer<Props> & EntityMapperPayload {
 
 		if (this.validator.isID(entity)) return (entity as any)?.value();
 

--- a/lib/core/entity.ts
+++ b/lib/core/entity.ts
@@ -1,4 +1,6 @@
-import { EntityMapperPayload, EntityProps, IAdapter, IEntity, IResult, ISettings, UID } from "../types";
+import { AutoMapperSerializer, EntityMapperPayload, EntityProps, IAdapter, IEntity, IResult, ISettings, UID } from "../types";
+import { ReadonlyDeep } from "../types-util";
+import { deepFreeze } from "../utils/deep-freeze.util";
 import AutoMapper from "./auto-mapper";
 import GettersAndSetters from "./getters-and-setters";
 import ID from "./id";
@@ -42,9 +44,15 @@ export class Entity<Props extends EntityProps> extends GettersAndSetters<Props> 
 	 * @description Get value as object from entity.
 	 * @returns object with properties.
 	 */
-	toObject<T>(adapter?: IAdapter<this, T>): T extends {} ? T & EntityMapperPayload : { [key in keyof Props]: any } & EntityMapperPayload {
+	toObject<T>(adapter?: IAdapter<this, T>)
+		: T extends {}
+		? T & EntityMapperPayload
+		: ReadonlyDeep<AutoMapperSerializer<Props> & EntityMapperPayload>  {
 		if (adapter && typeof adapter?.build === 'function') return adapter.build(this).value() as any;
-		return this.autoMapper.entityToObj(this) as any;
+
+		const serializedObject = this.autoMapper.entityToObj(this) as ReadonlyDeep<AutoMapperSerializer<Props>>;
+		const frozenObject = deepFreeze<any>(serializedObject);
+		return frozenObject
 	}
 
 	/**

--- a/lib/core/getters-and-setters.ts
+++ b/lib/core/getters-and-setters.ts
@@ -1,7 +1,6 @@
-import {  IParentName, ISettings } from "../types";
-import { ICreateManyDomain, IGettersAndSetters } from "../types";
-import  validator, { Validator } from "../utils/validator";
-import  util, { Utils } from "../utils/util";
+import { ICreateManyDomain, IGettersAndSetters, IParentName, ISettings } from "../types";
+import util, { Utils } from "../utils/util";
+import validator, { Validator } from "../utils/validator";
 import createManyDomainInstances from "./create-many-domain-instance";
 import ID from "./id";
 
@@ -11,7 +10,7 @@ import ID from "./id";
 export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 	protected validator: Validator = validator;
 	protected static validator: Validator = validator;
-	protected util: Utils = util;
+	protected util: Utils = util; 
 	protected static util: Utils = util;
 	private parentName: IParentName = 'ValueObject';
 
@@ -276,6 +275,10 @@ export class GettersAndSetters<Props> implements IGettersAndSetters<Props> {
 			this['props'] = Object.assign({}, { ...this['props'] }, { updatedAt: new Date() });
 		}
 		return true;
+	}
+
+	getRaw(): Props {
+		return this.props;
 	}
 
 }

--- a/lib/core/value-object.ts
+++ b/lib/core/value-object.ts
@@ -1,4 +1,6 @@
-import { IAdapter, IResult, ISettings, IValueObject } from "../types";
+import { AutoMapperSerializer, IAdapter, IResult, ISettings, IValueObject } from "../types";
+import { ReadonlyDeep } from "../types-util";
+import { deepFreeze } from "../utils/deep-freeze.util";
 import AutoMapper from "./auto-mapper";
 import GettersAndSetters from "./getters-and-setters";
 import Result from "./result";
@@ -45,9 +47,16 @@ export class ValueObject<Props> extends GettersAndSetters<Props> implements IVal
 	 * @description Get value from value object.
 	 * @returns value as string, number or any type defined.
 	 */
-	toObject<T>(adapter? :IAdapter<this, T>): T {
-		if (adapter && typeof adapter?.build === 'function') return adapter.build(this).value();
-		return this.autoMapper.valueObjectToObj(this) as unknown as T;
+	toObject<T>(adapter? :IAdapter<this, T>)
+		: T extends {}
+		? T
+		: ReadonlyDeep<AutoMapperSerializer<Props>> {
+		if (adapter && typeof adapter?.build === 'function') return adapter.build(this).value() as any
+
+		const serializedObject = this.autoMapper.valueObjectToObj(this) as ReadonlyDeep<AutoMapperSerializer<Props>>;
+		const frozenObject = deepFreeze<any>(serializedObject); 
+		return frozenObject
+ 
 	}
 
 	/** 

--- a/lib/types-util.ts
+++ b/lib/types-util.ts
@@ -1,0 +1,56 @@
+
+export type ReadonlyDeep<T> = T extends BuiltIns
+	? T
+	: T extends new (...arguments_: any[]) => unknown
+		? T // Skip class constructors
+		: T extends (...arguments_: any[]) => unknown
+			? {} extends ReadonlyObjectDeep<T>
+				? T
+				: HasMultipleCallSignatures<T> extends true
+					? T
+					: ((...arguments_: Parameters<T>) => ReturnType<T>) & ReadonlyObjectDeep<T>
+			: T extends Readonly<ReadonlyMap<infer KeyType, infer ValueType>>
+				? ReadonlyMapDeep<KeyType, ValueType>
+				: T extends Readonly<ReadonlySet<infer ItemType>>
+					? ReadonlySetDeep<ItemType>
+					: // Identify tuples to avoid converting them to arrays inadvertently; special case `readonly [...never[]]`, as it emerges undesirably from recursive invocations of ReadonlyDeep below.
+					T extends readonly [] | readonly [...never[]]
+						? readonly []
+						: T extends readonly [infer U, ...infer V]
+							? readonly [ReadonlyDeep<U>, ...ReadonlyDeep<V>]
+							: T extends readonly [...infer U, infer V]
+								? readonly [...ReadonlyDeep<U>, ReadonlyDeep<V>]
+								: T extends ReadonlyArray<infer ItemType>
+									? ReadonlyArray<ReadonlyDeep<ItemType>>
+									: T extends object
+										? ReadonlyObjectDeep<T>
+										: unknown;
+
+ 
+type ReadonlyMapDeep<KeyType, ValueType> = {} & Readonly<ReadonlyMap<ReadonlyDeep<KeyType>, ReadonlyDeep<ValueType>>>;
+type ReadonlySetDeep<ItemType> = {} & Readonly<ReadonlySet<ReadonlyDeep<ItemType>>>;
+type ReadonlyObjectDeep<ObjectType extends object> = {
+	readonly [KeyType in keyof ObjectType]: ReadonlyDeep<ObjectType[KeyType]>
+};
+
+type Primitive =
+	| null
+	| undefined
+	| string
+	| number
+	| boolean
+	| symbol
+	| bigint;
+type BuiltIns = Primitive | void | Date | RegExp;
+/**
+ * @description Deeply readonly object.
+ * @link https://github.com/sindresorhus/type-fest/blob/main/source/readonly-deep.d.ts
+ */
+type HasMultipleCallSignatures<T extends (...arguments_: any[]) => unknown> =
+	T extends {(...arguments_: infer A): unknown; (...arguments_: infer B): unknown}
+		? B extends A
+			? A extends B
+				? false
+				: true
+			: true
+		: false;

--- a/lib/utils/deep-freeze.util.ts
+++ b/lib/utils/deep-freeze.util.ts
@@ -1,0 +1,8 @@
+export const deepFreeze = <T extends object>(obj: T) => {
+  if (!obj || typeof obj !== 'object') return obj;
+
+  Object.keys(obj).forEach(prop => {
+    if (typeof obj[prop] === 'object' && !Object.isFrozen(obj[prop])) deepFreeze(obj[prop]);
+  });
+  return Object.freeze(obj) as any
+};

--- a/tests/core/value-object.spec.ts
+++ b/tests/core/value-object.spec.ts
@@ -65,13 +65,58 @@ describe('value-object', () => {
 
 	});
 
+	describe('toObject method', () => {
+		interface Props {
+			street: string;
+			number: number;
+			city: City;
+		}
+		class City extends ValueObject<'A' | 'B' | 'C'> { }
+		class Address extends ValueObject<Props> { }
+
+		it('should verify resolved types', () => {
+			const address = new Address({
+				city: new City('A'),
+				number: 123,
+				street: '5th Avenue'
+			});
+			const addressObject = address.toObject()
+
+			expect(addressObject).toEqual({
+				city: 'A',
+				number: 123,
+				street: '5th Avenue'
+			});
+			expect(addressObject.city).toBe('A');
+			expect(addressObject.number).toBe(123);
+			expect(addressObject.street).toBe('5th Avenue');
+			expect(addressObject.number.toExponential()).toBe('1.23e+2');
+			expect(addressObject.number.toFixed()).toBe('123');
+			expect(addressObject.city.concat('B')).toBe('AB');
+			expect(addressObject.city.toLowerCase()).toBe('a');
+			expect(addressObject.street.toUpperCase()).toBe('5TH AVENUE');
+		});
+
+		it ('should be imutable', () => {
+			const address = new Address({
+				city: new City('A'),
+				number: 123,
+				street: '5th Avenue'
+			});
+			const addressObject = address.toObject()
+			expect(Object.isFrozen(addressObject)).toBeTruthy();
+			expect(() => (addressObject as any).city = 'B').toThrowError();
+		});
+
+	});
+
 	describe('simple value-object', () => {
 
 		interface Props {
 			value: string;
 		};
 
-		class StringVo extends ValueObject<Props>{
+		class StringVo extends ValueObject<Props> {
 			private constructor(props: Props) {
 				super(props);
 			}
@@ -101,7 +146,7 @@ describe('value-object', () => {
 			value: string;
 		};
 
-		class StringVo extends ValueObject<Props>{
+		class StringVo extends ValueObject<Props> {
 			private constructor(props: Props) {
 				super(props);
 			}
@@ -132,7 +177,7 @@ describe('value-object', () => {
 			age: number;
 		};
 
-		class StringVo extends ValueObject<Props>{
+		class StringVo extends ValueObject<Props> {
 			private constructor(props: Props) {
 				super(props);
 			}
@@ -166,7 +211,7 @@ describe('value-object', () => {
 		});
 
 		it('should transform value object to object', () => {
-			class Sample extends ValueObject<string>{
+			class Sample extends ValueObject<string> {
 				private constructor(props: string) {
 					super(props);
 				}
@@ -179,7 +224,7 @@ describe('value-object', () => {
 
 
 		it('should transform value object to object', () => {
-			class Sample extends ValueObject<{ value: string }>{
+			class Sample extends ValueObject<{ value: string }> {
 				private constructor(props: { value: string }) {
 					super(props);
 				}
@@ -192,7 +237,7 @@ describe('value-object', () => {
 
 		it('should transform value object to object', () => {
 
-			class Sample extends ValueObject<{ value: string, foo: string }>{
+			class Sample extends ValueObject<{ value: string, foo: string }> {
 				private constructor(props: { value: string, foo: string }) {
 					super(props);
 				}
@@ -215,7 +260,7 @@ describe('value-object', () => {
 		});
 
 		it('should clone a value object with success', () => {
-			class Sample extends ValueObject<{ value: string, foo: string }>{
+			class Sample extends ValueObject<{ value: string, foo: string }> {
 				private constructor(props: { value: string, foo: string }) {
 					super(props);
 				}
@@ -231,7 +276,7 @@ describe('value-object', () => {
 		it('should clone a value object with custom props', () => {
 
 			interface Props { value: string; foo: string; }
-			class Sample extends ValueObject<Props>{
+			class Sample extends ValueObject<Props> {
 				private constructor(props: Props) {
 					super(props);
 				}
@@ -330,7 +375,7 @@ describe('value-object', () => {
 
 		interface Props3 { value: string, foo: string };
 
-		class Sample extends ValueObject<Props3>{
+		class Sample extends ValueObject<Props3> {
 			private constructor(props: Props3) {
 				super(props);
 			}


### PR DESCRIPTION
reference [issue](https://github.com/4lessandrodev/rich-domain/issues/145)

### Fix|Change|Update

This pull request aims to solve the problem of inferring the correct types in the toObject method 
implementing a serializer at type checking level without break changes. 

The only change made at runtime is that toObject returns a deepReadonly object

#issue #145
Resolves #145
