### PR TITLE
fix: change type create method return null #194

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-### [1.23.5] - 2024-10-18
+
+## Released
+
+---
+
+
+### [1.24.0] - 2024-11-28
 
 #### Fix
 
-## Changelog for `1.23.5-beta.0`
-
-### **Changes**
 - **Explicit Typing for Failures**: `Result.fail` now explicitly returns `Result<null, ...>`, ensuring that values are always `null` in failure states.
 - **New `isNull` Method**: Added to simplify validation of `null` values or failure states, improving readability and type safety.
 - **Adjusted Creation Methods**: Methods like `create` and adapters now return `Result<T | null>` where applicable for better consistency and error handling.
@@ -23,10 +26,6 @@ These changes improve type safety, make failure handling more explicit, and enco
 Feedback is welcome! 🚀
 
 [issue](https://github.com/4lessandrodev/rich-domain/issues/194)
-
-## Released
-
----
 
 ### Updates
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ export default class Money extends ValueObject<Props> {
     }
 
     // factory method to create an instance and validate value.
-    public static create(amount: number): Result<Money> {
+    public static create(amount: number): Result<Money | null> {
 
         const isValid = this.isValidProps({ amount });
         if(!isValid) return Fail("Invalid amount for money");
@@ -307,7 +307,7 @@ console.log(resA.isOk());
 
 
 // money instance
-const moneyA = resA.value();
+const moneyA = resA.value() as Money;
 
 moneyA.get("amount"); 
 
@@ -318,7 +318,7 @@ moneyA.isGt(Money.zero());
 
 // > true
 
-const moneyB = Money.create(100).value();
+const moneyB = Money.create(100).value() as Money;
 
 const moneyC = moneyA.sum(moneyB);
 
@@ -386,7 +386,7 @@ How to use entity instance
 ```ts
 
 // operation result
-const total = Money.create(500).value();
+const total = Money.create(500).value() as Money;
 const discount = Money.zero();
 const fees = Money.zero();
 
@@ -394,8 +394,8 @@ const fees = Money.zero();
 const payment = Payment.create({ total, discount, fees }).value();
 
 // create fee and discount
-const fee = Money.create(17.50).value();
-const disc = Money.create(170.50).value();
+const fee = Money.create(17.50).value() as Money;
+const disc = Money.create(170.50).value() as Money;
 
 // apply fee and discount
 const result = payment.applyFees(fee).applyDiscount(disc);
@@ -683,7 +683,7 @@ So let's implement that on a simple function.
 
 ```ts
 
-const isEven = (value: number): Result<Data, Err, Meta> => {
+const isEven = (value: number): Result<Data | null, Err, Meta> => {
 
 	const isEvenValue = value % 2 === 0;
 	const metaData: Meta = { arg: value };
@@ -762,7 +762,7 @@ Let's see the same example using void.
 
 ```ts
 
-const checkEven = (value: number): Result<void> => {
+const checkEven = (value: number): Result<void | null> => {
 
 	const isEven = value % 2 === 0;
 
@@ -1199,7 +1199,7 @@ export class Name extends ValueObject<string>{
         return new Name(value);
     }
 
-	public static create(value: string): Result<Name> {
+	public static create(value: string): Result<Name | null> {
 		if (!this.isValid(value)) return Fail('invalid name');
 		return Ok(new Name(value));
 	}
@@ -1253,9 +1253,9 @@ This method is useful for cases where you have value objects inside other value 
 
 ```ts
 
-const street = Street.create('Dom Juan').value();
+const street = Street.create('Dom Juan').value() as Street;
 
-const complement = Complement.create('n42').value();
+const complement = Complement.create('n42').value() as Complement;
 
 const result = Address.create({ street, complement });
 
@@ -1276,7 +1276,7 @@ This method creates a new instance with the same properties as the current value
 
 ```ts
 
-const result = Name.create('Sammy');
+const result = Name.create('Sammy') as Name;
 
 const originalName = result.value();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rich-domain",
-	"version": "1.23.5-beta-0",
+	"version": "1.24.0",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -19,10 +19,10 @@
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.8",
-		"@types/node": "^22.5.2",
+		"@types/node": "^22.10.0",
 		"jest": "^28.1.3",
 		"madge": "^6.0.0",
-		"rimraf": "^5.0.5",
+		"rimraf": "^5.0.10",
 		"ts-jest": "^28.0.5",
 		"ts-node": "^10.8.2",
 		"typescript": "^5.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,12 +703,19 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@*", "@types/node@^22.5.2":
+"@types/node@*":
   version "22.9.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.3.tgz#08f3d64b3bc6d74b162d36f60213e8a6704ef2b4"
   integrity sha512-F3u1fs/fce3FFk+DAxbxc78DF8x0cY09RRL8GnXLmkJ1jvx3TtPdWoTT5/NiYfI5ASqXBmfqJi9dZ3gxMx4lzw==
   dependencies:
     undici-types "~6.19.8"
+
+"@types/node@^22.10.0":
+  version "22.10.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.0.tgz#89bfc9e82496b9c7edea3382583fa94f75896e81"
+  integrity sha512-XC70cRZVElFHfIUB40FgZOBbgJYFKKMa5nb9lxcwYstFG/Mi+/Y0bGS+rs6Dmhmkpq4pnNiLiuZAbc02YCOnmA==
+  dependencies:
+    undici-types "~6.20.0"
 
 "@types/prettier@^2.1.5":
   version "2.7.0"
@@ -807,9 +814,9 @@ ansi-regex@^5.0.1:
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.1.0.tgz#95ec409c69619d6cb1b8b34f14b660ef28ebd654"
+  integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -1167,7 +1174,16 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1581,9 +1597,9 @@ flatten@^1.0.2:
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
 foreground-child@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.2.1.tgz#767004ccf3a5b30df39bed90718bab43fe0a59f7"
-  integrity sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.0.tgz#0ac8644c06e431439f8561db8ecf29a7b5519c77"
+  integrity sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
@@ -2600,9 +2616,9 @@ p-try@^2.0.0:
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 package-json-from-dist@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz#e501cd3094b278495eb4258d4c9f6d5ac3019f00"
-  integrity sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
 parse-json@^5.2.0:
   version "5.2.0"
@@ -2885,10 +2901,10 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^5.0.5:
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.9.tgz#c3baa1b886eadc2ec7981a06a593c3d01134ffe9"
-  integrity sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==
+rimraf@^5.0.10:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.10.tgz#23b9843d3dc92db71f96e1a2ce92e39fd2a8221c"
+  integrity sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==
   dependencies:
     glob "^10.3.7"
 
@@ -3278,6 +3294,11 @@ undici-types@~6.19.8:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+
+undici-types@~6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
+  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### [1.24.0] - 2024-11-28

#### Fix

- **Explicit Typing for Failures**: `Result.fail` now explicitly returns `Result<null, ...>`, ensuring that values are always `null` in failure states.
- **New `isNull` Method**: Added to simplify validation of `null` values or failure states, improving readability and type safety.
- **Adjusted Creation Methods**: Methods like `create` and adapters now return `Result<T | null>` where applicable for better consistency and error handling.

### **Impact**
These changes improve type safety, make failure handling more explicit, and encourage clearer checks in code. The updates may require minor adjustments in existing codebases to accommodate the explicit `null` typing in failures. This release is marked as beta for testing purposes. 

Feedback is welcome! 🚀

[issue](https://github.com/4lessandrodev/rich-domain/issues/194)